### PR TITLE
feat(frontend): findings table with severity facets, sort, search & URL filters

### DIFF
--- a/frontend/app/components/FindingsPanel.tsx
+++ b/frontend/app/components/FindingsPanel.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useMemo } from "react";
+import type { Finding } from "../types";
+import { filterFindings, severityCounts } from "../lib/findings-query";
+import { useFindingsQuery } from "./useFindingsQuery";
+import { SeverityFacets } from "./SeverityFacets";
+import { FindingsSearch } from "./FindingsSearch";
+import { FindingsTable } from "./FindingsTable";
+
+interface FindingsPanelProps {
+  findings: Finding[];
+}
+
+/**
+ * The results experience: severity facets + debounced search + a virtualized,
+ * sortable table, all driven by URL-backed state so the view is shareable.
+ * Must be rendered inside a <Suspense> boundary because it reads useSearchParams.
+ */
+export function FindingsPanel({ findings }: FindingsPanelProps) {
+  const {
+    state,
+    toggleSeverity,
+    clearSeverities,
+    setQuery,
+    setSort,
+    clearAll,
+    hasActiveFilters,
+  } = useFindingsQuery();
+
+  const counts = useMemo(
+    () => severityCounts(findings, state),
+    [findings, state]
+  );
+  const filtered = useMemo(
+    () => filterFindings(findings, state),
+    [findings, state]
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <SeverityFacets
+          selected={state.severities}
+          counts={counts}
+          onToggle={toggleSeverity}
+          onClear={clearSeverities}
+        />
+        <FindingsSearch value={state.q} onChange={setQuery} />
+      </div>
+
+      <p
+        className="text-sm text-zinc-500 dark:text-zinc-400 theme-high-contrast:text-white"
+        aria-live="polite"
+      >
+        {filtered.length === findings.length
+          ? `${findings.length} findings`
+          : `${filtered.length} of ${findings.length} findings`}
+      </p>
+
+      {filtered.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-zinc-300 dark:border-zinc-700 theme-high-contrast:border-white py-12 text-center">
+          <p className="text-zinc-500 dark:text-zinc-400 theme-high-contrast:text-white">
+            No findings match the current filters.
+          </p>
+          {hasActiveFilters && (
+            <button
+              type="button"
+              onClick={clearAll}
+              className="mt-3 rounded-lg border border-zinc-300 dark:border-zinc-600 theme-high-contrast:border-white px-3 py-1.5 text-sm font-medium hover:bg-zinc-100 dark:hover:bg-zinc-800"
+            >
+              Clear filters
+            </button>
+          )}
+        </div>
+      ) : (
+        <FindingsTable
+          rows={filtered}
+          sort={state.sort}
+          dir={state.dir}
+          onSortChange={setSort}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/app/components/FindingsSearch.stories.tsx
+++ b/frontend/app/components/FindingsSearch.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { FindingsSearch } from "./FindingsSearch";
+
+function Harness() {
+  const [value, setValue] = useState("");
+  return (
+    <div className="space-y-2">
+      <FindingsSearch value={value} onChange={setValue} />
+      <p className="text-sm text-zinc-500">
+        Debounced value: <code>{value || "(empty)"}</code>
+      </p>
+    </div>
+  );
+}
+
+const meta: Meta<typeof FindingsSearch> = {
+  title: "Components/FindingsSearch",
+  component: FindingsSearch,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component:
+          "Search input that keeps a responsive local value while debouncing the committed onChange (default 250ms), so the URL isn't rewritten on every keystroke.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof FindingsSearch>;
+
+export const Default: Story = {
+  render: () => <Harness />,
+};

--- a/frontend/app/components/FindingsSearch.tsx
+++ b/frontend/app/components/FindingsSearch.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface FindingsSearchProps {
+  /** The committed search term (source of truth, e.g. from the URL). */
+  value: string;
+  /** Called with the debounced value. */
+  onChange: (value: string) => void;
+  /** Debounce delay in ms. */
+  delay?: number;
+  placeholder?: string;
+}
+
+/**
+ * Search box that keeps a responsive local value while debouncing the committed
+ * `onChange` so we don't rewrite the URL on every keystroke. Re-syncs to `value`
+ * when it changes externally (e.g. "Clear filters").
+ */
+export function FindingsSearch({
+  value,
+  onChange,
+  delay = 250,
+  placeholder = "Search findings…",
+}: FindingsSearchProps) {
+  const [local, setLocal] = useState(value);
+
+  // Re-sync when the committed value changes from the outside.
+  useEffect(() => {
+    setLocal(value);
+  }, [value]);
+
+  // Debounce upward commits.
+  useEffect(() => {
+    if (local === value) return;
+    const id = setTimeout(() => onChange(local), delay);
+    return () => clearTimeout(id);
+  }, [local, value, delay, onChange]);
+
+  return (
+    <div className="relative w-full sm:w-72">
+      <input
+        type="search"
+        role="searchbox"
+        value={local}
+        onChange={(e) => setLocal(e.target.value)}
+        placeholder={placeholder}
+        aria-label="Search findings"
+        className="w-full rounded-lg border border-zinc-300 dark:border-zinc-600 theme-high-contrast:border-white bg-white dark:bg-zinc-950 theme-high-contrast:bg-black px-3 py-1.5 text-sm outline-none focus:ring-2 focus:ring-zinc-400 dark:focus:ring-zinc-600"
+      />
+    </div>
+  );
+}

--- a/frontend/app/components/FindingsTable.stories.tsx
+++ b/frontend/app/components/FindingsTable.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { FindingsTable } from "./FindingsTable";
+import type { Finding, Severity } from "../types";
+import type { SortDir, SortKey } from "../lib/findings-query";
+
+const severities: Severity[] = ["critical", "high", "medium", "low"];
+const categories = ["Auth Gap", "Panic/Unwrap", "Arithmetic", "Ledger Size", "Unsafe Pattern"];
+
+function makeFindings(count: number): Finding[] {
+  return Array.from({ length: count }, (_, i) => {
+    const severity = severities[i % severities.length];
+    const category = categories[i % categories.length];
+    return {
+      id: `f-${i}`,
+      severity,
+      category,
+      title: `${category} detected in handler #${i}`,
+      location: `src/lib.rs:${10 + i}`,
+      snippet: i % 3 === 0 ? `let value = input.parse::<u64>().unwrap(); // row ${i}` : undefined,
+      line: 1,
+      suggestion: i % 2 === 0 ? "Handle the error path explicitly." : undefined,
+      raw: null,
+    };
+  });
+}
+
+/** Interactive wrapper so the sort headers actually re-sort within the story. */
+function TableHarness({ rows }: { rows: Finding[] }) {
+  const [sort, setSort] = useState<SortKey | null>("severity");
+  const [dir, setDir] = useState<SortDir>("desc");
+  return (
+    <FindingsTable
+      rows={rows}
+      sort={sort}
+      dir={dir}
+      onSortChange={(s, d) => {
+        setSort(s);
+        setDir(d);
+      }}
+    />
+  );
+}
+
+const meta: Meta<typeof FindingsTable> = {
+  title: "Components/FindingsTable",
+  component: FindingsTable,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component:
+          "Virtualized, sortable findings table (TanStack Table + Virtual). Columns: severity, code, file:line, message. Rows with a snippet or suggestion expand inline. Sorting is controlled by the caller so it can be persisted to the URL.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof FindingsTable>;
+
+export const Default: Story = {
+  render: () => <TableHarness rows={makeFindings(25)} />,
+};
+
+/** Demonstrates virtualization staying smooth at 500+ rows. */
+export const ManyRows: Story = {
+  render: () => <TableHarness rows={makeFindings(600)} />,
+};

--- a/frontend/app/components/FindingsTable.tsx
+++ b/frontend/app/components/FindingsTable.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useCallback, useMemo, useRef, useState } from "react";
+import {
+  createColumnHelper,
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  useReactTable,
+  type OnChangeFn,
+  type Row,
+  type SortingState,
+} from "@tanstack/react-table";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import type { Finding, Severity } from "../types";
+import { CodeSnippet } from "./CodeSnippet";
+import { SEVERITY_RANK, type SortDir, type SortKey } from "../lib/findings-query";
+
+interface FindingsTableProps {
+  /** Already filtered findings; the table owns sorting + virtualization. */
+  rows: Finding[];
+  sort: SortKey | null;
+  dir: SortDir;
+  onSortChange: (sort: SortKey | null, dir: SortDir) => void;
+}
+
+const severityBadge: Record<Severity, string> = {
+  critical: "bg-red-500/15 text-red-700 dark:text-red-400 border border-red-500/50",
+  high: "bg-orange-500/15 text-orange-700 dark:text-orange-400 border border-orange-500/50",
+  medium: "bg-amber-500/15 text-amber-700 dark:text-amber-400 border border-amber-500/50",
+  low: "bg-zinc-500/15 text-zinc-700 dark:text-zinc-400 border border-zinc-500/50",
+};
+
+// Shared 12-column grid so the header and every row line up exactly.
+const GRID = "grid grid-cols-[7rem_8rem_minmax(8rem,1fr)_minmax(10rem,2fr)] items-center gap-3 px-4";
+
+const columnHelper = createColumnHelper<Finding>();
+
+const columns = [
+  columnHelper.accessor("severity", {
+    id: "severity",
+    header: "Severity",
+    // Order by weight (critical → low) rather than alphabetically.
+    sortingFn: (a, b) =>
+      SEVERITY_RANK[a.original.severity] - SEVERITY_RANK[b.original.severity],
+    cell: (ctx) => {
+      const s = ctx.getValue() as Severity;
+      return (
+        <span
+          className={`inline-block rounded px-2 py-0.5 text-xs font-semibold uppercase tracking-wide ${severityBadge[s]}`}
+        >
+          {s}
+        </span>
+      );
+    },
+  }),
+  columnHelper.accessor("category", {
+    id: "code",
+    header: "Code",
+    cell: (ctx) => (
+      <span className="truncate text-sm font-medium text-zinc-700 dark:text-zinc-300">
+        {ctx.getValue()}
+      </span>
+    ),
+  }),
+  columnHelper.accessor("location", {
+    id: "location",
+    header: "File:Line",
+    cell: (ctx) => (
+      <span className="truncate font-mono text-xs text-zinc-600 dark:text-zinc-400">
+        {ctx.getValue()}
+      </span>
+    ),
+  }),
+  columnHelper.accessor("title", {
+    id: "message",
+    header: "Message",
+    cell: (ctx) => (
+      <span className="truncate text-sm text-zinc-800 dark:text-zinc-200">
+        {ctx.getValue()}
+      </span>
+    ),
+  }),
+];
+
+function SortIndicator({ dir }: { dir: false | SortDir }) {
+  return (
+    <span aria-hidden className="ml-1 inline-block w-3 text-xs">
+      {dir === "asc" ? "▲" : dir === "desc" ? "▼" : ""}
+    </span>
+  );
+}
+
+/**
+ * Virtualized findings table (handles hundreds of rows). Sorting is controlled
+ * by the caller (URL-backed) via TanStack Table; rows are windowed with TanStack
+ * Virtual. Rows with a snippet/suggestion expand inline to show detail, using
+ * dynamic measurement so the virtualizer stays accurate.
+ */
+export function FindingsTable({ rows, sort, dir, onSortChange }: FindingsTableProps) {
+  // TanStack Table's useReactTable returns a mutable instance the React Compiler
+  // can't memoize; opt this component out per TanStack's guidance.
+  "use no memo";
+
+  const sorting: SortingState = useMemo(
+    () => (sort ? [{ id: sort, desc: dir === "desc" }] : []),
+    [sort, dir]
+  );
+
+  const handleSortingChange: OnChangeFn<SortingState> = useCallback(
+    (updater) => {
+      const next = typeof updater === "function" ? updater(sorting) : updater;
+      if (next.length === 0) {
+        onSortChange(null, "desc");
+      } else {
+        onSortChange(next[0].id as SortKey, next[0].desc ? "desc" : "asc");
+      }
+    },
+    [sorting, onSortChange]
+  );
+
+  const table = useReactTable({
+    data: rows,
+    columns,
+    state: { sorting },
+    onSortingChange: handleSortingChange,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+
+  const sortedRows = table.getRowModel().rows;
+
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const toggleExpanded = useCallback((id: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const virtualizer = useVirtualizer({
+    count: sortedRows.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => 48,
+    overscan: 12,
+  });
+
+  const hasDetail = (f: Finding) => Boolean(f.snippet || f.suggestion);
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-zinc-200 dark:border-zinc-800 theme-high-contrast:border-white">
+      {/* Header */}
+      <div
+        role="row"
+        className={`${GRID} border-b border-zinc-200 dark:border-zinc-800 theme-high-contrast:border-white bg-zinc-50 dark:bg-zinc-900 theme-high-contrast:bg-black py-2`}
+      >
+        {table.getHeaderGroups()[0].headers.map((header) => {
+          const sorted = header.column.getIsSorted();
+          return (
+            <div
+              key={header.id}
+              role="columnheader"
+              aria-sort={
+                sorted === "asc"
+                  ? "ascending"
+                  : sorted === "desc"
+                    ? "descending"
+                    : "none"
+              }
+            >
+              <button
+                type="button"
+                onClick={header.column.getToggleSortingHandler()}
+                className="flex w-full items-center text-left text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400 theme-high-contrast:text-white hover:text-zinc-900 dark:hover:text-zinc-100"
+              >
+                {flexRender(header.column.columnDef.header, header.getContext())}
+                <SortIndicator dir={sorted} />
+              </button>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Virtualized body */}
+      <div
+        ref={scrollRef}
+        className="max-h-[60vh] overflow-auto"
+        role="rowgroup"
+        aria-label="Findings"
+      >
+        <div
+          style={{ height: `${virtualizer.getTotalSize()}px`, position: "relative" }}
+        >
+          {virtualizer.getVirtualItems().map((virtualItem) => {
+            const row: Row<Finding> = sortedRows[virtualItem.index];
+            const f = row.original;
+            const isExpanded = expanded.has(f.id);
+            const expandable = hasDetail(f);
+
+            return (
+              <div
+                key={f.id}
+                ref={virtualizer.measureElement}
+                data-index={virtualItem.index}
+                className="absolute left-0 top-0 w-full border-b border-zinc-100 dark:border-zinc-800/60"
+                style={{ transform: `translateY(${virtualItem.start}px)` }}
+              >
+                <div
+                  role="row"
+                  className={`${GRID} py-2.5 ${
+                    expandable
+                      ? "cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-900/60"
+                      : ""
+                  }`}
+                  onClick={expandable ? () => toggleExpanded(f.id) : undefined}
+                  aria-expanded={expandable ? isExpanded : undefined}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <div key={cell.id} className="min-w-0" role="cell">
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </div>
+                  ))}
+                </div>
+
+                {expandable && isExpanded && (
+                  <div className="px-4 pb-4 pl-[7.75rem] text-sm">
+                    {f.suggestion && (
+                      <p className="mb-2 italic text-zinc-600 dark:text-zinc-400">
+                        💡 {f.suggestion}
+                      </p>
+                    )}
+                    {f.snippet && (
+                      <CodeSnippet code={f.snippet} highlightLine={f.line} />
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/components/SeverityFacets.stories.tsx
+++ b/frontend/app/components/SeverityFacets.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { SeverityFacets } from "./SeverityFacets";
+import type { Severity } from "../types";
+
+function Harness({ initial }: { initial: Severity[] }) {
+  const [selected, setSelected] = useState<Severity[]>(initial);
+  return (
+    <SeverityFacets
+      selected={selected}
+      counts={{ critical: 3, high: 7, medium: 12, low: 0 }}
+      onToggle={(s) =>
+        setSelected((prev) =>
+          prev.includes(s) ? prev.filter((x) => x !== s) : [...prev, s]
+        )
+      }
+      onClear={() => setSelected([])}
+    />
+  );
+}
+
+const meta: Meta<typeof SeverityFacets> = {
+  title: "Components/SeverityFacets",
+  component: SeverityFacets,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component:
+          "Multi-select severity facet chips with live counts. 'All' clears the selection; severities with a zero count are disabled.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SeverityFacets>;
+
+export const AllSelected: Story = {
+  render: () => <Harness initial={[]} />,
+};
+
+export const SomeSelected: Story = {
+  render: () => <Harness initial={["critical", "high"]} />,
+};

--- a/frontend/app/components/SeverityFacets.tsx
+++ b/frontend/app/components/SeverityFacets.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import type { Severity } from "../types";
+import { SEVERITY_ORDER } from "../lib/findings-query";
+
+interface SeverityFacetsProps {
+  /** Currently selected severities. Empty means "all". */
+  selected: Severity[];
+  /** Count of findings per severity (respecting the active search term). */
+  counts: Record<Severity, number>;
+  onToggle: (severity: Severity) => void;
+  onClear: () => void;
+}
+
+const labels: Record<Severity, string> = {
+  critical: "Critical",
+  high: "High",
+  medium: "Medium",
+  low: "Low",
+};
+
+const activeColors: Record<Severity, string> = {
+  critical: "bg-red-500 text-white border-red-500",
+  high: "bg-orange-500 text-white border-orange-500",
+  medium: "bg-amber-500 text-white border-amber-500",
+  low: "bg-zinc-500 text-white border-zinc-500",
+};
+
+const baseChip =
+  "rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40 theme-high-contrast:border-white";
+const idleChip =
+  "border-zinc-300 dark:border-zinc-700 bg-zinc-200 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300 hover:bg-zinc-300 dark:hover:bg-zinc-700 theme-high-contrast:bg-black theme-high-contrast:text-white";
+
+/** Multi-select severity facets. Toggling a chip adds/removes it; "All" clears the selection. */
+export function SeverityFacets({
+  selected,
+  counts,
+  onToggle,
+  onClear,
+}: SeverityFacetsProps) {
+  const allActive = selected.length === 0;
+
+  return (
+    <div
+      className="flex flex-wrap items-center gap-2"
+      role="group"
+      aria-label="Filter findings by severity"
+    >
+      <button
+        type="button"
+        onClick={onClear}
+        aria-pressed={allActive}
+        className={`${baseChip} ${
+          allActive
+            ? "bg-zinc-800 dark:bg-zinc-700 text-white border-zinc-800 dark:border-zinc-700"
+            : idleChip
+        }`}
+      >
+        All
+      </button>
+
+      {SEVERITY_ORDER.map((s) => {
+        const isSelected = selected.includes(s);
+        const count = counts[s] ?? 0;
+        return (
+          <button
+            key={s}
+            type="button"
+            onClick={() => onToggle(s)}
+            aria-pressed={isSelected}
+            disabled={count === 0 && !isSelected}
+            className={`${baseChip} ${isSelected ? activeColors[s] : idleChip}`}
+          >
+            {labels[s]}
+            <span className="ml-1.5 tabular-nums opacity-75">{count}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/app/components/useFindingsQuery.ts
+++ b/frontend/app/components/useFindingsQuery.ts
@@ -1,0 +1,96 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import type { Severity } from "../types";
+import {
+  parseFindingsQuery,
+  serializeFindingsQuery,
+  type FindingsQueryState,
+  type SortDir,
+  type SortKey,
+} from "../lib/findings-query";
+
+export interface UseFindingsQuery {
+  state: FindingsQueryState;
+  /** Add/remove a single severity facet. */
+  toggleSeverity: (severity: Severity) => void;
+  /** Clear all severity facets (back to "all"). */
+  clearSeverities: () => void;
+  /** Set the search term (callers debounce). */
+  setQuery: (q: string) => void;
+  /** Set or clear the active sort column. */
+  setSort: (sort: SortKey | null, dir: SortDir) => void;
+  /** Reset every filter back to the default view. */
+  clearAll: () => void;
+  /** Whether any filter/sort is currently active. */
+  hasActiveFilters: boolean;
+}
+
+/**
+ * Reads the findings view state from the URL and exposes setters that write it
+ * back via a shallow `router.replace` (no scroll jump, no history spam). The URL
+ * stays the single source of truth, so the view is always shareable.
+ */
+export function useFindingsQuery(): UseFindingsQuery {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const state = useMemo(
+    () => parseFindingsQuery(searchParams),
+    [searchParams]
+  );
+
+  const commit = useCallback(
+    (next: FindingsQueryState) => {
+      const qs = serializeFindingsQuery(next).toString();
+      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+    },
+    [router, pathname]
+  );
+
+  const toggleSeverity = useCallback(
+    (severity: Severity) => {
+      const has = state.severities.includes(severity);
+      const severities = has
+        ? state.severities.filter((s) => s !== severity)
+        : [...state.severities, severity];
+      commit({ ...state, severities });
+    },
+    [state, commit]
+  );
+
+  const clearSeverities = useCallback(
+    () => commit({ ...state, severities: [] }),
+    [state, commit]
+  );
+
+  const setQuery = useCallback(
+    (q: string) => commit({ ...state, q }),
+    [state, commit]
+  );
+
+  const setSort = useCallback(
+    (sort: SortKey | null, dir: SortDir) => commit({ ...state, sort, dir }),
+    [state, commit]
+  );
+
+  const clearAll = useCallback(
+    () => commit({ severities: [], q: "", sort: null, dir: "desc" }),
+    [commit]
+  );
+
+  const hasActiveFilters =
+    state.severities.length > 0 || state.q.trim().length > 0 || state.sort !== null;
+
+  return {
+    state,
+    toggleSeverity,
+    clearSeverities,
+    setQuery,
+    setSort,
+    clearAll,
+    hasActiveFilters,
+  };
+}

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { useState, useCallback } from "react";
-import type { AnalysisReport, CallGraphNode, CallGraphEdge, Finding, Severity } from "../types";
+import { useState, useCallback, Suspense } from "react";
+import type { AnalysisReport, CallGraphNode, CallGraphEdge, Finding } from "../types";
 import { transformReport, extractCallGraph } from "../lib/transform";
 import { exportToPdf } from "../lib/export-pdf";
-import { SeverityFilter } from "../components/SeverityFilter";
-import { FindingsList } from "../components/FindingsList";
+import { FindingsPanel } from "../components/FindingsPanel";
 import { SummaryChart } from "../components/SummaryChart";
 import { SanctityScore } from "../components/SanctityScore";
 import { CallGraph } from "../components/CallGraph";
@@ -29,7 +28,6 @@ export default function DashboardPage() {
   const [findings, setFindings] = useState<Finding[]>([]);
   const [callGraphNodes, setCallGraphNodes] = useState<CallGraphNode[]>([]);
   const [callGraphEdges, setCallGraphEdges] = useState<CallGraphEdge[]>([]);
-  const [severityFilter, setSeverityFilter] = useState<Severity | "all">("all");
   const [error, setError] = useState<string | null>(null);
   const [jsonInput, setJsonInput] = useState("");
   const [activeTab, setActiveTab] = useState<Tab>("findings");
@@ -247,13 +245,19 @@ export default function DashboardPage() {
                   aria-labelledby="findings-tab"
                 >
                   <section>
-                    <h2 className="text-lg font-semibold mb-4">Filter by Severity</h2>
-                    <SeverityFilter selected={severityFilter} onChange={setSeverityFilter} />
-                  </section>
-
-                  <section className="mt-8">
                     <h2 className="text-lg font-semibold mb-4">Findings</h2>
-                    <FindingsList findings={findings} severityFilter={severityFilter} />
+                    <Suspense
+                      fallback={
+                        <p
+                          className="py-8 text-center"
+                          style={{ color: "var(--muted-foreground)" }}
+                        >
+                          Loading findings…
+                        </p>
+                      }
+                    >
+                      <FindingsPanel findings={findings} />
+                    </Suspense>
                   </section>
                 </div>
               )}

--- a/frontend/app/lib/findings-query.ts
+++ b/frontend/app/lib/findings-query.ts
@@ -1,0 +1,159 @@
+import type { Finding, Severity } from "../types";
+
+/**
+ * Pure helpers for the findings results view.
+ *
+ * The URL search params are the single source of truth for the active view:
+ * severity facets, full-text search, and column sorting all serialize to the
+ * query string so a pasted link reproduces the exact same table. Everything in
+ * this module is framework-agnostic and side-effect free, which keeps the
+ * filtering/sorting logic easy to reason about and unit-test independently of
+ * React or the router.
+ */
+
+/** Canonical display + serialization order for severities. */
+export const SEVERITY_ORDER: readonly Severity[] = [
+  "critical",
+  "high",
+  "medium",
+  "low",
+];
+
+/** Higher number = more severe. Used as the sort weight for the severity column. */
+export const SEVERITY_RANK: Record<Severity, number> = {
+  critical: 3,
+  high: 2,
+  medium: 1,
+  low: 0,
+};
+
+export type SortKey = "severity" | "code" | "location" | "message";
+export type SortDir = "asc" | "desc";
+
+export interface FindingsQueryState {
+  /** Selected severity facets. Empty array means "all severities". */
+  severities: Severity[];
+  /** Debounced full-text search term. */
+  q: string;
+  /** Active sort column, or null for the natural (input) order. */
+  sort: SortKey | null;
+  /** Sort direction; only meaningful when {@link sort} is set. */
+  dir: SortDir;
+}
+
+export const EMPTY_QUERY: FindingsQueryState = {
+  severities: [],
+  q: "",
+  sort: null,
+  dir: "desc",
+};
+
+const VALID_SORT_KEYS: readonly SortKey[] = [
+  "severity",
+  "code",
+  "location",
+  "message",
+];
+
+/** Minimal read interface satisfied by both URLSearchParams and Next's ReadonlyURLSearchParams. */
+interface ReadableParams {
+  get(name: string): string | null;
+}
+
+function isSeverity(value: string): value is Severity {
+  return (SEVERITY_ORDER as readonly string[]).includes(value);
+}
+
+function isSortKey(value: string): value is SortKey {
+  return (VALID_SORT_KEYS as readonly string[]).includes(value);
+}
+
+/** Parse the findings view state from URL search params, ignoring anything malformed. */
+export function parseFindingsQuery(params: ReadableParams): FindingsQueryState {
+  const rawSeverities = (params.get("severity") ?? "")
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(isSeverity);
+  // De-duplicate and force canonical order so the serialized form is stable.
+  const severities = SEVERITY_ORDER.filter((s) => rawSeverities.includes(s));
+
+  const q = (params.get("q") ?? "").trim();
+
+  const rawSort = params.get("sort") ?? "";
+  const sort = isSortKey(rawSort) ? rawSort : null;
+
+  const dir: SortDir = params.get("dir") === "asc" ? "asc" : "desc";
+
+  return { severities, q, sort, dir };
+}
+
+/** Serialize view state back into URL search params, omitting defaults to keep links tidy. */
+export function serializeFindingsQuery(
+  state: FindingsQueryState
+): URLSearchParams {
+  const params = new URLSearchParams();
+
+  if (state.severities.length > 0) {
+    params.set(
+      "severity",
+      SEVERITY_ORDER.filter((s) => state.severities.includes(s)).join(",")
+    );
+  }
+
+  const q = state.q.trim();
+  if (q) params.set("q", q);
+
+  if (state.sort) {
+    params.set("sort", state.sort);
+    params.set("dir", state.dir);
+  }
+
+  return params;
+}
+
+function haystack(f: Finding): string {
+  return [f.title, f.category, f.location, f.snippet, f.suggestion]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+}
+
+/** Apply the severity facets + search term. Sorting is handled by the table itself. */
+export function filterFindings(
+  findings: Finding[],
+  state: FindingsQueryState
+): Finding[] {
+  const q = state.q.trim().toLowerCase();
+  const selected = new Set(state.severities);
+
+  return findings.filter((f) => {
+    if (selected.size > 0 && !selected.has(f.severity)) return false;
+    if (q && !haystack(f).includes(q)) return false;
+    return true;
+  });
+}
+
+/**
+ * Count findings per severity for the facet chips. Counts respect the active
+ * search term but ignore the severity selection itself, so each chip shows how
+ * many results selecting it would surface.
+ */
+export function severityCounts(
+  findings: Finding[],
+  state: FindingsQueryState
+): Record<Severity, number> {
+  const q = state.q.trim().toLowerCase();
+  const counts: Record<Severity, number> = {
+    critical: 0,
+    high: 0,
+    medium: 0,
+    low: 0,
+  };
+
+  for (const f of findings) {
+    if (q && !haystack(f).includes(q)) continue;
+    counts[f.severity] += 1;
+  }
+
+  return counts;
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/react-table": "^8.21.3",
+        "@tanstack/react-virtual": "^3.14.3",
         "jspdf": "^4.2.0",
         "next": "16.1.4",
         "react": "19.2.3",
@@ -3037,6 +3039,66 @@
         "@tailwindcss/oxide": "4.2.1",
         "postcss": "^8.5.6",
         "tailwindcss": "4.2.1"
+      }
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.3.tgz",
+      "integrity": "sha512-k/cnHPVaOfn46hSbiY6n4Dzf4QjCGWSF40zR5QIIYUqPAjpA6TN7InfYmcMiDVQGP2iUn9xsRbAl8u1v3UmeVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.1.tgz",
+      "integrity": "sha512-VZyW2Uiml5tmBZwPGrSD3Sz73OxzljQMCmzYHsUTPEuTsERf5xwa+uWb01xEzkz3ZSYTjj8NEb/mKHvgKxyZdA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,8 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-virtual": "^3.14.3",
     "jspdf": "^4.2.0",
     "next": "16.1.4",
     "react": "19.2.3",


### PR DESCRIPTION
Closes #371

## Overview
Replaces the single-select card list with a **virtualized, sortable findings table** whose entire view state lives in the **URL search params**. This makes the results view the deep-linkable, shareable centerpiece the issue asks for: a pasted link reproduces the exact severity selection, search term, and sort.

## Architecture
The flow is `URL searchParams → derived state → filtered rows → virtualized table`, with the URL as the single source of truth (no filter state hidden in component props).

- **`app/lib/findings-query.ts`** — framework-agnostic, side-effect-free helpers: `parseFindingsQuery` / `serializeFindingsQuery`, `filterFindings`, and `severityCounts`. Pure functions, trivial to unit-test.
- **`app/components/useFindingsQuery.ts`** — bridges `useSearchParams` ⇄ a shallow `router.replace` (no scroll jump, no history spam).
- **`app/components/SeverityFacets.tsx`** — multi-select severity chips with live counts (zero-count facets disabled).
- **`app/components/FindingsSearch.tsx`** — debounced (250ms) full-text search that stays responsive locally while throttling URL writes.
- **`app/components/FindingsTable.tsx`** — TanStack **Table** (column model + controlled, URL-backed sorting) + TanStack **Virtual** (row windowing). Columns: `severity · code · file:line · message`. Severity sorts by weight (critical → low). Rows with a snippet/suggestion expand inline (dynamic measurement keeps the virtualizer accurate).
- **`app/components/FindingsPanel.tsx`** — composes the above; wired into the dashboard Findings tab inside a `<Suspense>` boundary (required for `useSearchParams` during static prerender).

## URL contract
`?severity=high,critical&q=auth&sort=severity&dir=desc` — defaults are omitted to keep links tidy; malformed params are ignored.

## Acceptance criteria
- [x] **Virtualized table performant at 500+ rows** — TanStack Virtual windows rows; included a 600-row Storybook story (`FindingsTable › ManyRows`).
- [x] **Severity facets, sorting, and search work together** — all derive from the same URL state and compose.
- [x] **Filters serialized to the URL (shareable)** — severity, `q`, `sort`, `dir`.
- [x] **Empty state** — zero-results panel with a **Clear filters** action.

## Testing
- `npm run build` — ✅ passes; `/dashboard` still prerenders as static (Suspense boundary verified).
- `npx tsc --noEmit` — ✅ clean.
- `npm run lint` — no new errors. One **informational** warning remains: the React Compiler skips `FindingsTable` because TanStack Table's `useReactTable` returns a mutable instance it can't memoize. This is expected and handled with the documented `"use no memo"` directive.
- Added Storybook stories for `FindingsTable`, `SeverityFacets`, and `FindingsSearch`.

## Notes
- New dependencies: `@tanstack/react-table` (^8) and `@tanstack/react-virtual` (^3) — both React 19 compatible. This matches the issue's "TanStack Table + virtual" reference.
- The previous `FindingsList` / `SeverityFilter` components are left in place (still exported and covered by their stories); only the dashboard's Findings tab is switched over to the new table. Happy to remove them if you'd prefer.
