### PR TITLE
feat(reentrancy-guard): publish as standalone documented semver crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,3 +73,8 @@ jobs:
 
       - name: Build Release CLI
         run: cd tooling/sanctifier-cli && cargo build --release
+
+      - name: Build reentrancy-guard and protected-vault
+        run: |
+          cargo build -p reentrancy-guard
+          cargo build -p protected-vault

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,6 +1161,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "protected-vault"
+version = "0.1.0"
+dependencies = [
+ "reentrancy-guard",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "contracts/token-with-bugs",
     "contracts/amm-pool",
     "contracts/reentrancy-guard",
+    "contracts/protected-vault",
     "contracts/runtime-guard-wrapper",
     "contracts/kani-poc",
 ]

--- a/contracts/protected-vault/Cargo.toml
+++ b/contracts/protected-vault/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "protected-vault"
+version = "0.1.0"
+edition = "2021"
+description = "Example Soroban vault contract demonstrating reentrancy-guard integration"
+license = "MIT"
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+soroban-sdk = "20.5.0"
+reentrancy-guard = { path = "../reentrancy-guard" }
+
+[dev-dependencies]
+soroban-sdk = { version = "20.5.0", features = ["testutils"] }
+reentrancy-guard = { path = "../reentrancy-guard", features = ["testutils"] }
+
+[features]
+testutils = ["soroban-sdk/testutils", "reentrancy-guard/testutils"]
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true

--- a/contracts/protected-vault/src/lib.rs
+++ b/contracts/protected-vault/src/lib.rs
@@ -1,0 +1,53 @@
+#![no_std]
+
+use reentrancy_guard::ReentrancyGuard;
+use soroban_sdk::{contract, contractimpl, symbol_short, Env, Symbol};
+
+const BALANCE_KEY: Symbol = symbol_short!("BALANCE");
+
+/// A simple vault contract that uses `reentrancy-guard` to protect its state-mutating functions.
+#[contract]
+pub struct ProtectedVault;
+
+#[contractimpl]
+impl ProtectedVault {
+    /// Deposit `amount` into the vault.
+    pub fn deposit(env: Env, amount: i128) {
+        assert!(amount > 0, "amount must be positive");
+        let guard = ReentrancyGuard::new(&env);
+        guard.enter();
+        let balance: i128 = env.storage().instance().get(&BALANCE_KEY).unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&BALANCE_KEY, &(balance + amount));
+        guard.exit();
+    }
+
+    /// Withdraw `amount` from the vault.
+    pub fn withdraw(env: Env, amount: i128) {
+        assert!(amount > 0, "amount must be positive");
+        let guard = ReentrancyGuard::new(&env);
+        guard.enter();
+        let balance: i128 = env.storage().instance().get(&BALANCE_KEY).unwrap_or(0);
+        assert!(balance >= amount, "insufficient balance");
+        env.storage()
+            .instance()
+            .set(&BALANCE_KEY, &(balance - amount));
+        guard.exit();
+    }
+
+    /// Return the current vault balance.
+    pub fn balance(env: Env) -> i128 {
+        env.storage().instance().get(&BALANCE_KEY).unwrap_or(0)
+    }
+
+    /// Simulates a reentrant withdrawal: holds the guard then tries to call `withdraw` again.
+    /// In tests this demonstrates that the guard rejects the inner call with "reentrancy detected".
+    pub fn reentrant_withdraw(env: Env, amount: i128) {
+        let guard = ReentrancyGuard::new(&env);
+        guard.enter();
+        // The guard is already locked — this inner call should panic immediately.
+        Self::withdraw(env.clone(), amount);
+        guard.exit();
+    }
+}

--- a/contracts/protected-vault/tests/integration_test.rs
+++ b/contracts/protected-vault/tests/integration_test.rs
@@ -1,0 +1,61 @@
+#![no_std]
+
+use protected_vault::ProtectedVaultClient;
+use soroban_sdk::Env;
+
+#[test]
+fn test_deposit_and_balance() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, protected_vault::ProtectedVault);
+    let client = ProtectedVaultClient::new(&env, &contract_id);
+
+    client.deposit(&100_i128);
+    assert_eq!(client.balance(), 100_i128);
+}
+
+#[test]
+fn test_sequential_deposits_and_withdraw() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, protected_vault::ProtectedVault);
+    let client = ProtectedVaultClient::new(&env, &contract_id);
+
+    client.deposit(&200_i128);
+    client.deposit(&50_i128);
+    assert_eq!(client.balance(), 250_i128);
+
+    client.withdraw(&100_i128);
+    assert_eq!(client.balance(), 150_i128);
+}
+
+/// Simulates a reentrancy attack: the guard must detect the re-entry and abort.
+#[test]
+#[should_panic(expected = "reentrancy detected")]
+fn test_reentrant_withdraw_is_rejected() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, protected_vault::ProtectedVault);
+    let client = ProtectedVaultClient::new(&env, &contract_id);
+
+    client.deposit(&500_i128);
+    // reentrant_withdraw holds the lock then calls withdraw — should panic.
+    client.reentrant_withdraw(&100_i128);
+}
+
+#[test]
+#[should_panic(expected = "insufficient balance")]
+fn test_withdraw_exceeding_balance_panics() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, protected_vault::ProtectedVault);
+    let client = ProtectedVaultClient::new(&env, &contract_id);
+
+    client.deposit(&10_i128);
+    client.withdraw(&100_i128);
+}
+
+#[test]
+fn test_balance_is_zero_initially() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, protected_vault::ProtectedVault);
+    let client = ProtectedVaultClient::new(&env, &contract_id);
+
+    assert_eq!(client.balance(), 0_i128);
+}

--- a/contracts/reentrancy-guard/CHANGELOG.md
+++ b/contracts/reentrancy-guard/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] — 2026-06-18
+
+### Added
+
+- `GuardStatus` enum (`Unlocked = 0`, `Locked = 1`) with `from_u32` constructor.
+- `enter_pure(current_status) -> Result<GuardStatus, &'static str>` — pure state-transition
+  function; returns `Err("reentrancy detected")` if the guard is already locked.
+- `exit_pure() -> GuardStatus` — always returns `Unlocked`.
+- `ReentrancyGuard<'a>` — Soroban contract integration using instance storage key `RE_GRD`.
+  Exposes `enter()` (panics on reentrancy) and `exit()` (releases the lock).
+- `testutils` Cargo feature for test-harness integration with `soroban-sdk/testutils`.
+- Four Kani proof harnesses covering all state-machine transitions:
+  `verify_enter_fails_when_locked`, `verify_enter_succeeds_when_unlocked`,
+  `verify_exit_always_unlocks`, `verify_guard_state_machine`.
+- Full crate metadata for publication: `license`, `repository`, `keywords`, `categories`,
+  `readme`, `documentation`.
+- `contracts/protected-vault` integration example with reentrancy attack scenario test.

--- a/contracts/reentrancy-guard/Cargo.toml
+++ b/contracts/reentrancy-guard/Cargo.toml
@@ -2,7 +2,16 @@
 name = "reentrancy-guard"
 version = "0.1.0"
 edition = "2021"
-description = "Standardized, formally verified reentrancy guard for Soroban contracts"
+description = "Formally verified, no_std reentrancy guard for Soroban smart contracts"
+license = "MIT"
+authors = ["Centurylong Contributors"]
+repository = "https://github.com/Centurylong/sanctifier"
+homepage = "https://github.com/Centurylong/sanctifier/tree/main/contracts/reentrancy-guard"
+documentation = "https://docs.rs/reentrancy-guard"
+readme = "README.md"
+keywords = ["soroban", "stellar", "reentrancy", "guard", "security"]
+categories = ["cryptography::cryptocurrencies", "no-std"]
+rust-version = "1.78"
 
 [lib]
 crate-type = ["rlib"]

--- a/contracts/reentrancy-guard/README.md
+++ b/contracts/reentrancy-guard/README.md
@@ -1,0 +1,136 @@
+# reentrancy-guard
+
+A formally verified, `#![no_std]`-compatible reentrancy guard for
+[Soroban](https://stellar.org/soroban) smart contracts.
+
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](../../LICENSE)
+
+## Overview
+
+Reentrancy attacks occur when a malicious contract calls back into the victim contract before
+the first invocation completes. This crate provides a lightweight guard that stores a lock
+flag in Soroban instance storage, preventing any reentrant call from proceeding.
+
+The state-transition core (`enter_pure` / `exit_pure`) is verified exhaustively with
+[Kani](https://model-checking.github.io/kani/), giving mathematical certainty that the
+state machine is correct for all possible inputs.
+
+## Installation
+
+Add to your contract's `Cargo.toml`:
+
+```toml
+[dependencies]
+reentrancy-guard = "0.1"
+```
+
+## Quick Start
+
+```rust
+use reentrancy_guard::ReentrancyGuard;
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct MyVault;
+
+#[contractimpl]
+impl MyVault {
+    pub fn withdraw(env: Env, amount: i128) {
+        let guard = ReentrancyGuard::new(&env);
+        guard.enter();          // panics with "reentrancy detected" if re-entered
+
+        // … safely perform the withdrawal …
+
+        guard.exit();
+    }
+}
+```
+
+The guard stores a single `u32` flag under the storage key `RE_GRD` in Soroban instance
+storage. Calling `enter()` while the flag is already set causes an immediate panic, aborting
+the transaction.
+
+## API
+
+### `GuardStatus`
+
+```rust
+pub enum GuardStatus {
+    Unlocked = 0,
+    Locked   = 1,
+}
+
+impl GuardStatus {
+    pub fn from_u32(val: u32) -> Self;
+}
+```
+
+Represents the state of the guard in storage.
+
+---
+
+### `enter_pure(current_status: GuardStatus) -> Result<GuardStatus, &'static str>`
+
+Pure state-transition function with no side effects. Returns `Ok(Locked)` when transitioning
+from `Unlocked`, or `Err("reentrancy detected")` if already `Locked`. This is the target of
+Kani formal verification.
+
+---
+
+### `exit_pure() -> GuardStatus`
+
+Always returns `GuardStatus::Unlocked`. Call this after the protected section completes.
+
+---
+
+### `ReentrancyGuard<'a>`
+
+```rust
+impl<'a> ReentrancyGuard<'a> {
+    /// Create a new guard bound to the contract environment.
+    pub fn new(env: &'a Env) -> Self;
+
+    /// Enter a protected section. Panics on reentrancy.
+    pub fn enter(&self);
+
+    /// Exit a protected section, releasing the lock.
+    pub fn exit(&self);
+}
+```
+
+## Security Properties
+
+| Property | Status | Verified by |
+|---|---|---|
+| Cannot enter a locked section | Proven | `verify_enter_fails_when_locked` |
+| Entering an unlocked section succeeds | Proven | `verify_enter_succeeds_when_unlocked` |
+| Exit always unlocks | Proven | `verify_exit_always_unlocks` |
+| Full state-machine coverage | Proven | `verify_guard_state_machine` |
+
+## Kani Formal Verification
+
+The pure logic is verified with four Kani proof harnesses:
+
+```
+verify_enter_fails_when_locked       — entering a locked guard always errors
+verify_enter_succeeds_when_unlocked  — entering an unlocked guard always succeeds
+verify_exit_always_unlocks           — exit always sets state to Unlocked
+verify_guard_state_machine           — exhaustive two-state transition check
+```
+
+To run verification locally (requires [Kani](https://model-checking.github.io/kani/install-guide.html)):
+
+```bash
+cd contracts/reentrancy-guard
+cargo kani
+```
+
+## Integration Example
+
+See [`contracts/protected-vault`](../protected-vault) in this repository for a complete Soroban
+vault contract that uses this guard and includes an integration test demonstrating that a
+simulated reentrancy attack is caught and rejected.
+
+## License
+
+MIT

--- a/contracts/reentrancy-guard/src/lib.rs
+++ b/contracts/reentrancy-guard/src/lib.rs
@@ -1,3 +1,32 @@
+//! # reentrancy-guard
+//!
+//! A formally verified, `#![no_std]`-compatible reentrancy guard for
+//! [Soroban](https://stellar.org/soroban) smart contracts.
+//!
+//! ## Quick start
+//!
+//! ```toml
+//! [dependencies]
+//! reentrancy-guard = "0.1"
+//! ```
+//!
+//! ```ignore
+//! use reentrancy_guard::ReentrancyGuard;
+//! use soroban_sdk::{contractimpl, Env};
+//!
+//! pub fn withdraw(env: Env, amount: i128) {
+//!     let guard = ReentrancyGuard::new(&env);
+//!     guard.enter();   // panics if called again before exit()
+//!     // … perform withdrawal …
+//!     guard.exit();
+//! }
+//! ```
+//!
+//! ## Formal verification
+//!
+//! The pure state-transition logic is verified with
+//! [Kani](https://model-checking.github.io/kani/).
+//! Run `cargo kani` to replay the proofs locally.
 #![no_std]
 
 use soroban_sdk::{symbol_short, Env, Symbol};


### PR DESCRIPTION
Fixes #385

## What changed

- **`contracts/reentrancy-guard/Cargo.toml`** — added full publish metadata: `license`, `authors`, `repository`, `homepage`, `documentation`, `readme`, `keywords`, `categories`, `rust-version`
- **`contracts/reentrancy-guard/src/lib.rs`** — added crate-level `//!` doc block with installation snippet and Kani verification summary
- **`contracts/reentrancy-guard/README.md`** — overview, installation, quick-start, API reference table, security properties table, Kani verification instructions
- **`contracts/reentrancy-guard/CHANGELOG.md`** — initial `[0.1.0]` entry following Keep a Changelog format
- **`contracts/protected-vault/`** (new) — sample Soroban vault contract that depends on `reentrancy-guard`, demonstrating real-world integration; added to workspace members
- **`.github/workflows/ci.yml`** — new step builds both crates on every push/PR

## Why

Issue #385 requires the guard to be publication-ready with metadata, README, semver changelog, and an integration test in a sample contract so other Soroban projects can depend on it.

## How to test

Build the crates:
```bash
cargo build -p reentrancy-guard
cargo build -p protected-vault
```

The integration tests in `contracts/protected-vault/tests/integration_test.rs` cover five scenarios:
- normal deposit and balance query
- sequential deposits and partial withdrawal
- reentrancy attack rejected with `"reentrancy detected"` panic
- overdraft rejected with `"insufficient balance"` panic
- zero initial balance

> **Note:** `cargo test --features testutils` currently fails workspace-wide due to a pre-existing dependency conflict: `soroban-env-common 20.3.0` pins `arbitrary = "=1.3.2"` exactly, which is incompatible with `derive_arbitrary 1.4.2` already present in Cargo.lock. This affects all contract test targets in the repo. The library code itself compiles cleanly (`cargo check` / `cargo build` pass).