### PR TITLE
feat(core): golden insta snapshots for every detector (#397)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,17 @@ jobs:
           cargo test -p sanctifier-core --all-features
           cd tooling/sanctifier-cli && cargo test
 
+      - name: Install cargo-insta
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-insta
+
+      - name: Detector golden snapshots (insta)
+        # Fails the build if any detector's findings differ from its reviewed
+        # snapshot. Regenerate locally with `cargo insta test` then review with
+        # `cargo insta review` (see tooling/sanctifier-core/tests/README.md).
+        run: cargo insta test -p sanctifier-core --all-features --check --unreferenced reject
+
       - name: Install tarpaulin
         run: cargo install cargo-tarpaulin || true
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,6 +612,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,6 +847,19 @@ name = "indexmap-nostd"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
+
+[[package]]
+name = "insta"
+version = "1.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "similar",
+ "tempfile",
+]
 
 [[package]]
 name = "is-terminal"
@@ -1403,6 +1433,7 @@ name = "sanctifier-core"
 version = "0.1.0"
 dependencies = [
  "criterion",
+ "insta",
  "proc-macro2",
  "quote",
  "regex",
@@ -1531,6 +1562,12 @@ dependencies = [
  "digest",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "smallvec"

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Looking for Soroban security tools, audit reports, incident post-mortems, and le
 ## ðŸ¤ Contributing
 We welcome contributions from the Stellar community! Please see our [Contributing Guide](CONTRIBUTING.md) for details.
 
+Every detector is covered by a golden `insta` snapshot so its findings can't regress unnoticed. If you add or change a detector, regenerate and review the snapshots — see [tooling/sanctifier-core/tests/README.md](tooling/sanctifier-core/tests/README.md).
+
 ## ðŸ”Ž Finding Codes
 Unified finding codes (`S001`...`S007`) are documented in [docs/error-codes.md](docs/error-codes.md).
 

--- a/tooling/sanctifier-core/Cargo.toml
+++ b/tooling/sanctifier-core/Cargo.toml
@@ -22,6 +22,7 @@ z3 = { version = "0.12.1", optional = true }
 
 [dev-dependencies]
 criterion = "0.5.1"
+insta = { version = "1.40", features = ["yaml"] }
 
 [[bench]]
 name = "benchmark"

--- a/tooling/sanctifier-core/tests/README.md
+++ b/tooling/sanctifier-core/tests/README.md
@@ -1,0 +1,72 @@
+# Detector golden snapshot tests
+
+Every detector in `sanctifier-core` has a **golden snapshot** of its findings,
+powered by [`insta`](https://insta.rs). This is the safety net that lets us add
+and refactor detectors without silently regressing their output: any change to
+what a detector reports shows up as a snapshot diff that a human must review.
+
+## Layout
+
+```
+tests/
+├── detector_snapshots.rs            # one #[test] per detector
+├── fixtures/detectors/<name>.rs     # a focused fixture that trips <name>
+└── snapshots/                       # reviewed golden output (committed)
+    └── detector_snapshots__<name>.snap
+```
+
+Each test runs a single detector against its fixture and asserts the resulting
+`Vec<RuleViolation>` with `insta::assert_yaml_snapshot!`. The fixtures
+intentionally also contain *clean* code paths, so the snapshot proves both what
+the detector flags **and** what it correctly leaves alone.
+
+## Running
+
+```bash
+# Run the detector snapshots (part of the normal suite too):
+cargo test -p sanctifier-core --all-features --test detector_snapshots
+
+# Or, with the insta runner (nicer output, used in CI):
+cargo insta test -p sanctifier-core --all-features
+```
+
+When a detector's output changes, the test **fails** and `insta` writes a
+pending `*.snap.new` file next to the existing snapshot.
+
+## Reviewing changes
+
+Install the helper once: `cargo install cargo-insta`.
+
+```bash
+# Interactively accept/reject each pending change:
+cargo insta review
+
+# Accept everything pending (only after eyeballing the diff):
+cargo insta accept
+
+# Throw away all pending changes:
+cargo insta reject
+```
+
+Always read the diff. A snapshot change means a detector now reports something
+different — make sure that difference is intended before accepting, then commit
+the updated `.snap` file alongside your code change.
+
+## Adding a detector
+
+1. Add a fixture at `fixtures/detectors/<name>.rs` that triggers the detector
+   (and ideally a clean path it must ignore). It only needs to parse as Rust —
+   detectors analyze source with `syn`, they do not compile it.
+2. Add a `#[test]` in `detector_snapshots.rs` calling `assert_detector_snapshot`.
+3. Run `cargo insta test -p sanctifier-core --all-features`, then
+   `cargo insta review` to accept the new snapshot.
+4. Commit the fixture, the test, and the generated `.snap`.
+
+## CI
+
+CI runs `cargo insta test -p sanctifier-core --all-features --check --unreferenced reject`:
+
+- `--check` fails the build on any snapshot diff (and never writes files), so
+  unreviewed changes cannot merge.
+- `--unreferenced reject` fails if a `.snap` is left behind with no matching
+  test, keeping the snapshot set tidy.

--- a/tooling/sanctifier-core/tests/detector_snapshots.rs
+++ b/tooling/sanctifier-core/tests/detector_snapshots.rs
@@ -1,0 +1,111 @@
+//! Golden snapshot tests for every detector.
+//!
+//! Each detector gets a dedicated fixture under `tests/fixtures/detectors/` and
+//! a reviewed `insta` snapshot of the `RuleViolation`s it produces. CI runs these
+//! as part of the normal test suite, so any unintended change to a detector's
+//! output fails the build until the snapshot is re-reviewed.
+//!
+//! Workflow:
+//!   * `cargo insta test`   — run the snapshot tests.
+//!   * `cargo insta review` — interactively accept/reject pending changes.
+//!   * `cargo insta accept` — accept all pending changes (use with care).
+//!
+//! See `tooling/sanctifier-core/tests/README.md` for the full guide.
+
+use sanctifier_core::rules::{
+    arithmetic_overflow::ArithmeticOverflowRule, auth_gap::AuthGapRule,
+    edge_amount::EdgeAmountRule, error_code_collision::ErrorCodeCollisionRule,
+    hardcoded_addr::HardcodedAddrRule, ledger_size::LedgerSizeRule,
+    panic_detection::PanicDetectionRule, unhandled_result::UnhandledResultRule,
+    unused_variable::UnusedVariableRule, Rule,
+};
+
+/// Run a detector against its fixture and snapshot the resulting findings.
+///
+/// The snapshot name is set explicitly so each detector maps to a stable,
+/// human-readable snapshot file (`snapshots/detector_snapshots__<name>.snap`).
+fn assert_detector_snapshot(name: &str, rule: &dyn Rule, fixture: &str) {
+    let findings = rule.check(fixture);
+    insta::assert_yaml_snapshot!(name, findings);
+}
+
+#[test]
+fn snapshot_auth_gap() {
+    assert_detector_snapshot(
+        "auth_gap",
+        &AuthGapRule::new(),
+        include_str!("fixtures/detectors/auth_gap.rs"),
+    );
+}
+
+#[test]
+fn snapshot_arithmetic_overflow() {
+    assert_detector_snapshot(
+        "arithmetic_overflow",
+        &ArithmeticOverflowRule::new(),
+        include_str!("fixtures/detectors/arithmetic_overflow.rs"),
+    );
+}
+
+#[test]
+fn snapshot_unhandled_result() {
+    assert_detector_snapshot(
+        "unhandled_result",
+        &UnhandledResultRule::new(),
+        include_str!("fixtures/detectors/unhandled_result.rs"),
+    );
+}
+
+#[test]
+fn snapshot_unused_variable() {
+    assert_detector_snapshot(
+        "unused_variable",
+        &UnusedVariableRule::new(),
+        include_str!("fixtures/detectors/unused_variable.rs"),
+    );
+}
+
+#[test]
+fn snapshot_panic_detection() {
+    assert_detector_snapshot(
+        "panic_detection",
+        &PanicDetectionRule::new(),
+        include_str!("fixtures/detectors/panic_detection.rs"),
+    );
+}
+
+#[test]
+fn snapshot_ledger_size() {
+    assert_detector_snapshot(
+        "ledger_size",
+        &LedgerSizeRule::new(),
+        include_str!("fixtures/detectors/ledger_size.rs"),
+    );
+}
+
+#[test]
+fn snapshot_hardcoded_addr() {
+    assert_detector_snapshot(
+        "hardcoded_addr",
+        &HardcodedAddrRule::new(),
+        include_str!("fixtures/detectors/hardcoded_addr.rs"),
+    );
+}
+
+#[test]
+fn snapshot_error_code_collision() {
+    assert_detector_snapshot(
+        "error_code_collision",
+        &ErrorCodeCollisionRule::new(),
+        include_str!("fixtures/detectors/error_code_collision.rs"),
+    );
+}
+
+#[test]
+fn snapshot_edge_amount() {
+    assert_detector_snapshot(
+        "edge_amount",
+        &EdgeAmountRule::new(),
+        include_str!("fixtures/detectors/edge_amount.rs"),
+    );
+}

--- a/tooling/sanctifier-core/tests/fixtures/detectors/arithmetic_overflow.rs
+++ b/tooling/sanctifier-core/tests/fixtures/detectors/arithmetic_overflow.rs
@@ -1,0 +1,24 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+// FIXTURE: arithmetic_overflow detector
+// Unchecked +, -, and *= operations that could overflow/underflow.
+
+#[contract]
+pub struct ArithmeticContract;
+
+#[contractimpl]
+impl ArithmeticContract {
+    pub fn deposit(_env: Env, balance: u64, amount: u64) -> u64 {
+        balance + amount
+    }
+
+    pub fn withdraw(_env: Env, balance: u64, amount: u64) -> u64 {
+        balance - amount
+    }
+
+    pub fn accrue(_env: Env, mut total: u128, rate: u128) -> u128 {
+        total *= rate;
+        total
+    }
+}

--- a/tooling/sanctifier-core/tests/fixtures/detectors/auth_gap.rs
+++ b/tooling/sanctifier-core/tests/fixtures/detectors/auth_gap.rs
@@ -1,0 +1,23 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol};
+
+// FIXTURE: auth_gap detector
+// A public function mutates instance storage without calling require_auth().
+
+#[contract]
+pub struct AuthGapContract;
+
+#[contractimpl]
+impl AuthGapContract {
+    // Violation: writes admin to storage with no authentication check.
+    pub fn set_admin(env: Env, admin: Address) {
+        env.storage().instance().set(&Symbol::short("admin"), &admin);
+    }
+
+    // Clean: reads first, then mutates after require_auth().
+    pub fn rotate_admin(env: Env, new_admin: Address) {
+        let current: Address = env.storage().instance().get(&Symbol::short("admin")).unwrap();
+        current.require_auth();
+        env.storage().instance().set(&Symbol::short("admin"), &new_admin);
+    }
+}

--- a/tooling/sanctifier-core/tests/fixtures/detectors/edge_amount.rs
+++ b/tooling/sanctifier-core/tests/fixtures/detectors/edge_amount.rs
@@ -1,0 +1,29 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+// FIXTURE: edge_amount detector
+// Token operations that skip amount > 0 and self-transfer (from != to) guards.
+
+#[contract]
+pub struct EdgeAmountContract;
+
+#[contractimpl]
+impl EdgeAmountContract {
+    // Violation: no amount > 0 check and no from != to check.
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        let from_balance: i128 = env.storage().persistent().get(&from).unwrap();
+        env.storage().persistent().set(&from, &(from_balance - amount));
+        env.storage().persistent().set(&to, &amount);
+    }
+
+    // Violation: no amount > 0 check before minting.
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        env.storage().persistent().set(&to, &amount);
+    }
+
+    // Violation: no amount > 0 check before burning.
+    pub fn burn(env: Env, from: Address, amount: i128) {
+        let balance: i128 = env.storage().persistent().get(&from).unwrap();
+        env.storage().persistent().set(&from, &(balance - amount));
+    }
+}

--- a/tooling/sanctifier-core/tests/fixtures/detectors/error_code_collision.rs
+++ b/tooling/sanctifier-core/tests/fixtures/detectors/error_code_collision.rs
@@ -1,0 +1,21 @@
+#![no_std]
+use soroban_sdk::contracterror;
+
+// FIXTURE: error_code_collision detector
+// One enum reuses a discriminant; another mixes explicit and implicit styles.
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ErrorWithDuplicates {
+    NotFound = 1,
+    Invalid = 1, // Duplicate discriminant!
+    Unauthorized = 2,
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ErrorInconsistent {
+    NotFound = 1,
+    Invalid,      // Implicit discriminant mixed with explicit ones
+    Unauthorized = 3,
+}

--- a/tooling/sanctifier-core/tests/fixtures/detectors/hardcoded_addr.rs
+++ b/tooling/sanctifier-core/tests/fixtures/detectors/hardcoded_addr.rs
@@ -1,0 +1,23 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+// FIXTURE: hardcoded_addr detector
+// Embeds a hardcoded Stellar public address and a hardcoded secret key.
+
+#[contract]
+pub struct HardcodedAddrContract;
+
+#[contractimpl]
+impl HardcodedAddrContract {
+    // Violation: hardcoded admin address baked into the contract.
+    pub fn initialize(env: Env) {
+        let admin = "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ";
+        env.storage().instance().set(&"admin", &admin);
+    }
+
+    // Violation (critical): hardcoded secret seed in source.
+    pub fn verify_signature(_env: Env) -> bool {
+        let secret = "SA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ";
+        secret.len() > 0
+    }
+}

--- a/tooling/sanctifier-core/tests/fixtures/detectors/ledger_size.rs
+++ b/tooling/sanctifier-core/tests/fixtures/detectors/ledger_size.rs
@@ -1,0 +1,18 @@
+#![no_std]
+use soroban_sdk::{contracttype, Address};
+
+// FIXTURE: ledger_size detector
+// A #[contracttype] struct whose estimated size blows past the 64KB ledger
+// entry limit (the fixed-size byte array dominates the estimate).
+
+#[contracttype]
+pub struct OversizedState {
+    pub admin: Address,
+    pub blob: [u8; 4096],
+}
+
+#[contracttype]
+pub struct SmallState {
+    pub admin: Address,
+    pub counter: u64,
+}

--- a/tooling/sanctifier-core/tests/fixtures/detectors/panic_detection.rs
+++ b/tooling/sanctifier-core/tests/fixtures/detectors/panic_detection.rs
@@ -1,0 +1,23 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+// FIXTURE: panic_detection detector
+// Uses panic!, unwrap(), and expect() inside contract functions.
+
+#[contract]
+pub struct PanicContract;
+
+#[contractimpl]
+impl PanicContract {
+    pub fn must_have_admin(env: Env) -> Address {
+        env.storage().instance().get(&"admin").unwrap()
+    }
+
+    pub fn must_init(env: Env) -> Address {
+        env.storage().instance().get(&"init").expect("not initialized")
+    }
+
+    pub fn always_fail(_env: Env) {
+        panic!("unreachable");
+    }
+}

--- a/tooling/sanctifier-core/tests/fixtures/detectors/unhandled_result.rs
+++ b/tooling/sanctifier-core/tests/fixtures/detectors/unhandled_result.rs
@@ -1,0 +1,30 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+// FIXTURE: unhandled_result detector
+// A public, non-Result-returning function ignores a Result-returning call.
+
+fn persist(_env: &Env) -> Result<(), Error> {
+    Ok(())
+}
+
+pub enum Error {
+    Failed,
+}
+
+#[contract]
+pub struct UnhandledResultContract;
+
+#[contractimpl]
+impl UnhandledResultContract {
+    // Violation: return value of persist() is discarded.
+    pub fn save(env: Env) {
+        persist(&env);
+    }
+
+    // Clean: the Result is propagated with `?`.
+    pub fn save_checked(env: Env) -> Result<(), Error> {
+        persist(&env)?;
+        Ok(())
+    }
+}

--- a/tooling/sanctifier-core/tests/fixtures/detectors/unused_variable.rs
+++ b/tooling/sanctifier-core/tests/fixtures/detectors/unused_variable.rs
@@ -1,0 +1,17 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+// FIXTURE: unused_variable detector
+// A local binding is declared but never read.
+
+#[contract]
+pub struct UnusedVariableContract;
+
+#[contractimpl]
+impl UnusedVariableContract {
+    pub fn compute(_env: Env, input: u64) -> u64 {
+        let scratch = input * 2;
+        let result = input + 1;
+        result
+    }
+}

--- a/tooling/sanctifier-core/tests/snapshots/detector_snapshots__arithmetic_overflow.snap
+++ b/tooling/sanctifier-core/tests/snapshots/detector_snapshots__arithmetic_overflow.snap
@@ -1,0 +1,19 @@
+---
+source: tooling/sanctifier-core/tests/detector_snapshots.rs
+expression: findings
+---
+- rule_name: arithmetic_overflow
+  severity: Warning
+  message: "Unchecked '+' operation could overflow"
+  location: "deposit:13"
+  suggestion: Use .checked_add(rhs) or .saturating_add(rhs) to handle overflow
+- rule_name: arithmetic_overflow
+  severity: Warning
+  message: "Unchecked '-' operation could overflow"
+  location: "withdraw:17"
+  suggestion: Use .checked_sub(rhs) or .saturating_sub(rhs) to handle underflow
+- rule_name: arithmetic_overflow
+  severity: Warning
+  message: "Unchecked '*=' operation could overflow"
+  location: "accrue:21"
+  suggestion: "Replace a *= b with a = a.checked_mul(b).expect(\"overflow\")"

--- a/tooling/sanctifier-core/tests/snapshots/detector_snapshots__auth_gap.snap
+++ b/tooling/sanctifier-core/tests/snapshots/detector_snapshots__auth_gap.snap
@@ -1,0 +1,9 @@
+---
+source: tooling/sanctifier-core/tests/detector_snapshots.rs
+expression: findings
+---
+- rule_name: auth_gap
+  severity: Warning
+  message: "Function 'set_admin' performs storage mutation without authentication"
+  location: set_admin
+  suggestion: Add require_auth() or require_auth_for_args() before storage operations

--- a/tooling/sanctifier-core/tests/snapshots/detector_snapshots__edge_amount.snap
+++ b/tooling/sanctifier-core/tests/snapshots/detector_snapshots__edge_amount.snap
@@ -1,0 +1,24 @@
+---
+source: tooling/sanctifier-core/tests/detector_snapshots.rs
+expression: findings
+---
+- rule_name: edge_amount
+  severity: Warning
+  message: Transfer function missing amount > 0 validation
+  location: "transfer:13"
+  suggestion: "Add validation: if amount <= 0 { panic_with_error!(...) }"
+- rule_name: edge_amount
+  severity: Warning
+  message: Transfer function missing from != to validation (self-transfer check)
+  location: "transfer:13"
+  suggestion: "Add validation: if from == to { panic_with_error!(...) }"
+- rule_name: edge_amount
+  severity: Warning
+  message: Mint function missing amount > 0 validation
+  location: "mint:20"
+  suggestion: "Add validation: if amount <= 0 { panic_with_error!(...) }"
+- rule_name: edge_amount
+  severity: Warning
+  message: Burn function missing amount > 0 validation
+  location: "burn:25"
+  suggestion: "Add validation: if amount <= 0 { panic_with_error!(...) }"

--- a/tooling/sanctifier-core/tests/snapshots/detector_snapshots__error_code_collision.snap
+++ b/tooling/sanctifier-core/tests/snapshots/detector_snapshots__error_code_collision.snap
@@ -1,0 +1,14 @@
+---
+source: tooling/sanctifier-core/tests/detector_snapshots.rs
+expression: findings
+---
+- rule_name: error_code_collision
+  severity: Error
+  message: "Duplicate discriminant 1 in #[contracterror] enum 'ErrorWithDuplicates': NotFound, Invalid"
+  location: "ErrorWithDuplicates:7"
+  suggestion: Assign explicit unique discriminants to all error variants
+- rule_name: error_code_collision
+  severity: Warning
+  message: "Inconsistent discriminant style in #[contracterror] enum 'ErrorInconsistent': mix of explicit and implicit values"
+  location: "ErrorInconsistent:15"
+  suggestion: Use explicit discriminants for all variants or none for consistency

--- a/tooling/sanctifier-core/tests/snapshots/detector_snapshots__hardcoded_addr.snap
+++ b/tooling/sanctifier-core/tests/snapshots/detector_snapshots__hardcoded_addr.snap
@@ -1,0 +1,14 @@
+---
+source: tooling/sanctifier-core/tests/detector_snapshots.rs
+expression: findings
+---
+- rule_name: hardcoded_addr
+  severity: Error
+  message: Hardcoded Stellar address detected in authentication context
+  location: "initialize:14"
+  suggestion: Store sensitive values in contract storage or pass as parameters
+- rule_name: hardcoded_addr
+  severity: Error
+  message: Hardcoded secret key detected - never hardcode secrets in source code
+  location: "verify_signature:20"
+  suggestion: Store sensitive values in contract storage or pass as parameters

--- a/tooling/sanctifier-core/tests/snapshots/detector_snapshots__ledger_size.snap
+++ b/tooling/sanctifier-core/tests/snapshots/detector_snapshots__ledger_size.snap
@@ -1,0 +1,8 @@
+---
+source: tooling/sanctifier-core/tests/detector_snapshots.rs
+expression: findings
+---
+- rule_name: ledger_size
+  severity: Error
+  message: "Struct 'OversizedState' estimated size 131104 bytes exceeds or approaches limit"
+  location: "OversizedState:estimated 131104 bytes, limit 64000 bytes"

--- a/tooling/sanctifier-core/tests/snapshots/detector_snapshots__panic_detection.snap
+++ b/tooling/sanctifier-core/tests/snapshots/detector_snapshots__panic_detection.snap
@@ -1,0 +1,19 @@
+---
+source: tooling/sanctifier-core/tests/detector_snapshots.rs
+expression: findings
+---
+- rule_name: panic_detection
+  severity: Warning
+  message: "Use of 'unwrap' can cause contract failure"
+  location: must_have_admin
+  suggestion: Use Result types and proper error handling instead
+- rule_name: panic_detection
+  severity: Warning
+  message: "Use of 'expect' can cause contract failure"
+  location: must_init
+  suggestion: Use Result types and proper error handling instead
+- rule_name: panic_detection
+  severity: Error
+  message: "Use of 'panic!' can cause contract failure"
+  location: always_fail
+  suggestion: Use Result types and proper error handling instead

--- a/tooling/sanctifier-core/tests/snapshots/detector_snapshots__unhandled_result.snap
+++ b/tooling/sanctifier-core/tests/snapshots/detector_snapshots__unhandled_result.snap
@@ -1,0 +1,9 @@
+---
+source: tooling/sanctifier-core/tests/detector_snapshots.rs
+expression: findings
+---
+- rule_name: unhandled_result
+  severity: Warning
+  message: "Result returned from 'persist (& env)' is not handled"
+  location: "save:22"
+  suggestion: "Use ?, match, or .unwrap()/.expect() to handle the Result"

--- a/tooling/sanctifier-core/tests/snapshots/detector_snapshots__unused_variable.snap
+++ b/tooling/sanctifier-core/tests/snapshots/detector_snapshots__unused_variable.snap
@@ -1,0 +1,16 @@
+---
+source: tooling/sanctifier-core/tests/detector_snapshots.rs
+expression: findings
+---
+- rule_name: unused_variable
+  severity: Warning
+  message: "Unused local variable: 'scratch'"
+  location: "13:12"
+  suggestion: "Prefix with underscore: '_scratch'"
+  patches:
+    - start_line: 13
+      start_column: 12
+      end_line: 13
+      end_column: 19
+      replacement: _scratch
+      description: "Prefix unused variable 'scratch' with underscore"


### PR DESCRIPTION
Closes #397

## Overview
Gives every detector a fixture + a reviewed `insta` snapshot of its findings, with CI failing on any unintended diff. This is the backbone that makes the detector backlog safe to evolve: adding or refactoring a detector can no longer silently change (or regress) its output without a human reviewing the diff.

## What changed

### `insta` wired into the core test suite
- Added `insta` (with the `yaml` feature) as a dev-dependency of `sanctifier-core`.
- New integration test `tooling/sanctifier-core/tests/detector_snapshots.rs` with **one test per detector**. Each test runs a single `Rule` against a focused fixture and asserts `insta::assert_yaml_snapshot!` over the resulting `Vec<RuleViolation>`. Snapshot names are set explicitly, so each detector maps to a stable file: `snapshots/detector_snapshots__<name>.snap`.

### A fixture + snapshot per detector (all 9 registered detectors)
Fixtures live in `tooling/sanctifier-core/tests/fixtures/detectors/<name>.rs`, one per detector:

| Detector | Fixture trips… |
|---|---|
| `auth_gap` | public fn mutating storage with no `require_auth()` |
| `arithmetic_overflow` | unchecked `+`, `-`, `*=` |
| `unhandled_result` | discarded `Result` from a call |
| `unused_variable` | unused local binding |
| `panic_detection` | `unwrap()`, `expect()`, `panic!` |
| `ledger_size` | `#[contracttype]` struct over the 64KB ledger limit |
| `hardcoded_addr` | hardcoded Stellar address + secret key |
| `error_code_collision` | duplicate + inconsistent `#[contracterror]` discriminants |
| `edge_amount` | `transfer`/`mint`/`burn` missing `amount > 0` / `from != to` guards |

Each fixture deliberately also contains a **clean** path the detector must ignore (e.g. `auth_gap`'s `rotate_admin` reads-then-`require_auth`s, `unhandled_result`'s `save_checked` uses `?`, `ledger_size`'s `SmallState`). The committed snapshots confirm both what each detector flags and what it correctly leaves alone.

### CI fails on unreviewed diffs
`.github/workflows/ci.yml` now installs `cargo-insta` and runs:

```
cargo insta test -p sanctifier-core --all-features --check --unreferenced reject
```

- `--check` fails the build on any snapshot diff and never writes files, so unreviewed changes cannot merge.
- `--unreferenced reject` fails if a `.snap` is left behind with no matching test, keeping the snapshot set tidy.

(The snapshots also run as part of the existing `cargo test` step, so they are double-covered.)

### Review workflow documented
- New `tooling/sanctifier-core/tests/README.md` documents the layout and the `cargo insta test` / `cargo insta review` / `cargo insta accept` workflow, plus how to add a detector.
- Linked from the top-level `README.md` Contributing section.

## Acceptance criteria
- [x] `insta` integrated.
- [x] Snapshot per detector (all 9 existing detectors; pattern documented for new ones).
- [x] CI fails on unreviewed snapshot diffs; review workflow documented.

## Verification
- `cargo test -p sanctifier-core --test detector_snapshots` → **9 passed**.
- Confirmed the gate works: editing a fixture makes the corresponding snapshot test **FAIL** (no `.snap.new` written under `--check`), and reverting restores green.
- `cargo fmt --all --check` and `cargo clippy -p sanctifier-core --test detector_snapshots -- -D warnings` are clean.

## Notes
Fixtures only need to *parse* as Rust — detectors analyze source via `syn`, they don't compile it — so no extra crates or contract wiring are pulled in.