### PR TITLE
feat(ci): repo automation — path labeler, PR-size labels, CODEOWNERS (#522)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# Code owners for Sanctifier.
+#
+# GitHub auto-requests a review from the matching owner(s) when a PR touches
+# these paths. The last matching pattern wins. Owners must have write access
+# for the auto-request to take effect.
+#
+# Maintainers: adjust per-area owners below as the team grows.
+
+# Default owner for everything in the repo.
+*                           @Gbangbolaoluwagbemiga
+
+# CI/CD, release engineering, and repo automation.
+/.github/                   @Gbangbolaoluwagbemiga
+/scripts/                   @Gbangbolaoluwagbemiga
+
+# Core analysis engine and tooling.
+/tooling/                   @Gbangbolaoluwagbemiga

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,78 @@
+# Path-based PR labeler configuration (actions/labeler@v5).
+# Labels referenced here already exist in the repository.
+# See .github/workflows/labeler.yml for the workflow that applies these.
+
+"area: ci/cd":
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+          - ".github/labeler.yml"
+
+"area: infra":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "Dockerfile"
+          - ".dockerignore"
+          - "scripts/**"
+          - ".github/dependabot.yml"
+
+"area: contracts":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "contracts/**"
+          - "my-contract/**"
+
+"area: core-engine":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "tooling/sanctifier-core/**"
+          - "tooling/sanctify-macros/**"
+
+"area: cli":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "tooling/sanctifier-cli/**"
+
+"area: wasm":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "tooling/sanctifier-wasm/**"
+
+"area: frontend":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "frontend/**"
+          - "packages/**"
+
+"area: docs":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.md"
+          - "docs/**"
+
+"area: testing":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/tests/**"
+          - "**/benches/**"
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/Cargo.toml"
+          - "Cargo.lock"
+          - "**/package.json"
+          - "**/package-lock.json"
+
+rust:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.rs"
+
+javascript:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.js"
+          - "**/*.jsx"
+          - "**/*.ts"
+          - "**/*.tsx"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,26 @@
+name: PR Labeler
+
+# Applies path-based area/type labels to pull requests using .github/labeler.yml.
+#
+# Uses `pull_request_target` so the workflow definition and token come from the
+# base branch — this lets labeling work for PRs from forks (the common case for
+# this widely-forked repo) without exposing a write token to PR-author code.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: Apply area labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: true

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -1,0 +1,36 @@
+name: PR Size Labeler
+
+# Adds a size/XS..size/XL label to each PR based on the number of changed lines,
+# so reviewers can triage by effort at a glance. The action creates the size
+# labels on first run if they don't already exist.
+#
+# Uses `pull_request_target` so labeling works for fork PRs with the base repo's
+# token (see .github/workflows/labeler.yml for the same rationale).
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  size-label:
+    name: Apply size label
+    runs-on: ubuntu-latest
+    steps:
+      - uses: codelytv/pr-size-labeler@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          xs_max_size: "10"
+          s_max_size: "100"
+          m_max_size: "500"
+          l_max_size: "1000"
+          fail_if_xl: "false"
+          message_if_xl: ""
+          files_to_ignore: |
+            "Cargo.lock"
+            "**/package-lock.json"
+            "**/*.snap"


### PR DESCRIPTION
## Summary

Implements the **Repo automation** acceptance criterion of the CI/CD hardening epic **#522**: path-based labeler, PR-size labels, and CODEOWNERS auto-assign. All net-new `.github/` config — **no Rust/build files are touched**, so the existing CI pipeline is unaffected.

## What changed

### Path-based labeler — `.github/labeler.yml` + `.github/workflows/labeler.yml`
- `actions/labeler@v5` applies the repo's **existing** labels based on changed paths — no new labels invented:
  - `area: ci/cd`, `area: infra`, `area: contracts`, `area: core-engine`, `area: cli`, `area: wasm`, `area: frontend`, `area: docs`, `area: testing`
  - plus `rust`, `javascript`, `dependencies`
- Mapped to the actual workspace layout (`tooling/sanctifier-core`, `tooling/sanctifier-cli`, `tooling/sanctifier-wasm`, `contracts/`, `frontend/`, etc.).

### PR-size labels — `.github/workflows/pr-size.yml`
- `codelytv/pr-size-labeler` tags each PR `size/XS`…`size/XL` by changed lines so reviewers can triage by effort. Lockfiles and `*.snap` snapshots are excluded from the count; the size labels are created on first run.

### CODEOWNERS — `.github/CODEOWNERS`
- Auto-requests the maintainer on every PR, with per-area entries for `/.github/`, `/scripts/`, and `/tooling/`.

## Why `pull_request_target`
Both labeling workflows trigger on `pull_request_target` rather than `pull_request`. This is the standard pattern for a widely-forked repo: the workflow definition and token come from the **base** branch, so labeling works for fork PRs without ever handing a write-scoped token to PR-author code.

A direct consequence: because these workflows live on `pull_request_target` and aren't on `main` yet, they **do not run on this PR** and add no new required check — they activate for subsequent PRs once merged. This PR is therefore gated only by the existing `CI` workflow, which is green (no Rust changes).

## Scope note
Issue #522 is an epic bundling several infra criteria (workspace-wide lint gate, coverage/benchmark gates, cargo-dist release artifacts, SBOM, pre-commit hooks, status badges, multi-platform CI templates). This PR deliberately scopes to the **Repo automation** bullet to keep it small and reviewable; the remaining criteria are best landed as their own PRs.

## Testing
- All three YAML files validated as well-formed.
- `actions/labeler@v5` config uses the v5 `changed-files` / `any-glob-to-any-file` schema.
- No application/build files changed → existing `CI` workflow is unaffected.
