### PR TITLE
feat(frontend): historical Sanctity Score trend chart on /dashboard

### DIFF
--- a/frontend/app/components/ScoreTrendChart.stories.tsx
+++ b/frontend/app/components/ScoreTrendChart.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ScoreTrendChart } from "./ScoreTrendChart";
+import {
+  DEFAULT_FIXTURES,
+  createInMemoryScoreHistoryAdapter,
+} from "../lib/score-history/adapter";
+
+// The chart pulls its data through a typed adapter so stories can drive each
+// state by passing the in-memory adapter with the relevant fixture key. The
+// permalink work (issue #364) will swap the real adapter at the dashboard
+// call site without touching the component.
+const adapter = createInMemoryScoreHistoryAdapter(DEFAULT_FIXTURES);
+
+const meta: Meta<typeof ScoreTrendChart> = {
+  title: "Components/ScoreTrendChart",
+  component: ScoreTrendChart,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component:
+          "Historical Sanctity Score line chart for a tracked contract. Severity bands render as ReferenceArea overlays so the line stays the focal point. Range selector pins to 7d, 30d, or all and collapses to all when the dataset is shorter than the requested window.",
+      },
+    },
+  },
+  args: {
+    adapter,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ScoreTrendChart>;
+
+export const Healthy: Story = {
+  name: "Healthy trend",
+  args: {
+    contractId: "demo-healthy",
+  },
+};
+
+export const Regression: Story = {
+  name: "Regression spike",
+  args: {
+    contractId: "demo-regression",
+  },
+};
+
+export const SinglePoint: Story = {
+  name: "Single point",
+  args: {
+    contractId: "demo-single",
+  },
+};
+
+export const Empty: Story = {
+  name: "Empty history",
+  args: {
+    contractId: "demo-empty",
+  },
+};

--- a/frontend/app/components/ScoreTrendChart.tsx
+++ b/frontend/app/components/ScoreTrendChart.tsx
@@ -1,0 +1,354 @@
+"use client";
+
+// ScoreTrendChart renders the Sanctity Score over time for a single contract
+// or repo on the dashboard. Backs the time-series story called out in
+// issue #378.
+//
+// Design notes worth keeping in the code rather than the PR description:
+//
+//  - Severity bands are ReferenceArea overlays, not separate series, so the
+//    line stays the visual focus and the bands reflow with the chart on
+//    resize. Colour reads from the same CSS variables the gauge uses, so
+//    light and dark mode follow the existing theme tokens for free.
+//  - The range selector is rendered here. It is keyboard reachable and
+//    visually shows the active range. When the requested range collapses
+//    to "all" because the dataset is shorter than the window, the helper
+//    text below the chart calls it out instead of silently widening.
+//  - The single-point state renders the dot with an annotation rather than
+//    a degenerate line. recharts will draw a line of length zero if you
+//    let it; we explicitly switch to the "dot" presentation in that case.
+//  - The tooltip surfaces three pieces of information the gauge does not
+//    expose elsewhere: the score, the delta against the previous datapoint,
+//    and the severity category whose count changed most. The category line
+//    is what makes the chart a story rather than a number.
+
+import { useMemo, useState } from "react";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ReferenceArea,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { Severity } from "../types";
+import { SCORE_BANDS, type Range, type HistoricalScorePoint } from "../lib/score-history/types";
+import { useScoreHistory } from "../lib/score-history/useScoreHistory";
+import type { ScoreHistoryAdapter } from "../lib/score-history/types";
+
+export interface ScoreTrendChartProps {
+  contractId: string;
+  // Optional adapter override. The default in-memory adapter ships fixtures
+  // for stories and the dashboard demo; production code passes the
+  // persisted-history adapter once #364 lands.
+  adapter?: ScoreHistoryAdapter;
+  className?: string;
+}
+
+const RANGES: { value: Range; label: string }[] = [
+  { value: "7d", label: "7d" },
+  { value: "30d", label: "30d" },
+  { value: "all", label: "All" },
+];
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+// Return the severity whose count moved the most between two snapshots.
+// Ties break in favour of the worse severity (critical > high > medium > low)
+// because that is the one a reviewer cares about most.
+function biggestMover(
+  a: HistoricalScorePoint["breakdown"],
+  b: HistoricalScorePoint["breakdown"],
+): { severity: Severity; delta: number } | null {
+  const order: Severity[] = ["critical", "high", "medium", "low"];
+  let best: { severity: Severity; delta: number } | null = null;
+  for (const sev of order) {
+    const delta = (b[sev] ?? 0) - (a[sev] ?? 0);
+    if (delta === 0) continue;
+    if (!best || Math.abs(delta) > Math.abs(best.delta)) {
+      best = { severity: sev, delta };
+    }
+  }
+  return best;
+}
+
+type TrendTooltipPoint = HistoricalScorePoint & {
+  previous: HistoricalScorePoint | null;
+};
+
+interface TrendTooltipProps {
+  active?: boolean;
+  payload?: ReadonlyArray<{ payload: TrendTooltipPoint }>;
+}
+
+function TrendTooltip({ active, payload }: TrendTooltipProps) {
+  if (!active || !payload || payload.length === 0) return null;
+  const point = payload[0].payload;
+  const prev = point.previous;
+  const delta = prev ? point.score - prev.score : null;
+  const mover = prev ? biggestMover(prev.breakdown, point.breakdown) : null;
+
+  return (
+    <div
+      className="rounded-md border px-3 py-2 text-xs shadow-md"
+      style={{
+        backgroundColor: "var(--card)",
+        color: "var(--card-foreground)",
+        borderColor: "var(--border)",
+      }}
+      role="tooltip"
+    >
+      <div className="font-semibold mb-1">{formatDate(point.timestamp)}</div>
+      <div>
+        Score <span className="font-mono">{point.score}</span>{" "}
+        <span style={{ color: "var(--muted-foreground)" }}>(grade {point.grade})</span>
+      </div>
+      {delta !== null && (
+        <div className="mt-0.5">
+          Delta{" "}
+          <span
+            className="font-mono"
+            style={{
+              color:
+                delta > 0
+                  ? "var(--success)"
+                  : delta < 0
+                    ? "var(--severity-critical)"
+                    : "var(--muted-foreground)",
+            }}
+          >
+            {delta > 0 ? "+" : ""}
+            {delta}
+          </span>
+        </div>
+      )}
+      {mover && (
+        <div className="mt-0.5" style={{ color: "var(--muted-foreground)" }}>
+          Driven by {mover.delta > 0 ? "+" : ""}
+          {mover.delta} {mover.severity} finding{Math.abs(mover.delta) === 1 ? "" : "s"}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ScoreTrendChart({
+  contractId,
+  adapter,
+  className,
+}: ScoreTrendChartProps) {
+  const [range, setRange] = useState<Range>("30d");
+  const adapterOption = useMemo(
+    () => (adapter ? { adapter } : {}),
+    [adapter],
+  );
+  const view = useScoreHistory(contractId, range, adapterOption);
+
+  const chartData = useMemo(() => {
+    return view.points.map((p, idx, all) => ({
+      ...p,
+      // ms key so recharts treats the axis as a true time axis even
+      // though the timestamps round-trip as strings through JSON.
+      t: new Date(p.timestamp).getTime(),
+      previous: idx > 0 ? all[idx - 1] : null,
+    }));
+  }, [view.points]);
+
+  const isSinglePoint = view.points.length === 1;
+  const collapsedToAll =
+    range !== "all" && view.effectiveRange === "all" && view.points.length > 0;
+
+  return (
+    <section
+      className={`rounded-lg border p-6 ${className ?? ""}`}
+      style={{
+        borderColor: "var(--border)",
+        backgroundColor: "var(--card)",
+        color: "var(--card-foreground)",
+      }}
+      aria-labelledby="score-trend-heading"
+    >
+      <header className="flex items-start justify-between gap-4 mb-4">
+        <div>
+          <h3 id="score-trend-heading" className="text-sm font-semibold">
+            Sanctity Score Trend
+          </h3>
+          <p className="text-xs mt-0.5" style={{ color: "var(--muted-foreground)" }}>
+            Historical score for{" "}
+            <span className="font-mono" style={{ color: "var(--foreground)" }}>
+              {contractId}
+            </span>
+          </p>
+        </div>
+
+        <div
+          role="group"
+          aria-label="Select time range"
+          className="inline-flex rounded-md border overflow-hidden"
+          style={{ borderColor: "var(--border)" }}
+        >
+          {RANGES.map((r) => {
+            const isActive = r.value === range;
+            return (
+              <button
+                key={r.value}
+                type="button"
+                onClick={() => setRange(r.value)}
+                aria-pressed={isActive}
+                className="px-2.5 py-1 text-xs font-medium transition-colors focus:outline-none focus:ring-2"
+                style={{
+                  backgroundColor: isActive
+                    ? "var(--primary)"
+                    : "transparent",
+                  color: isActive
+                    ? "var(--primary-foreground)"
+                    : "var(--muted-foreground)",
+                }}
+              >
+                {r.label}
+              </button>
+            );
+          })}
+        </div>
+      </header>
+
+      {view.isLoading && (
+        <div
+          className="h-56 flex items-center justify-center text-sm"
+          style={{ color: "var(--muted-foreground)" }}
+          aria-busy="true"
+          aria-live="polite"
+        >
+          Loading score history…
+        </div>
+      )}
+
+      {!view.isLoading && view.isEmpty && (
+        <div
+          className="h-56 flex flex-col items-center justify-center text-sm gap-1"
+          style={{ color: "var(--muted-foreground)" }}
+        >
+          <span>No history yet for this contract.</span>
+          <span className="text-xs">
+            Run an analysis to record the first datapoint.
+          </span>
+        </div>
+      )}
+
+      {!view.isLoading && !view.isEmpty && (
+        <>
+          <div className="h-56 w-full">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={chartData} margin={{ top: 8, right: 12, left: 0, bottom: 4 }}>
+                <CartesianGrid
+                  strokeDasharray="3 3"
+                  stroke="var(--border)"
+                  vertical={false}
+                />
+                {/* Severity overlays. Drawn before the line so the line wins
+                    visual focus. Each band uses the matching CSS variable
+                    with a low alpha so the colour is just a hint. */}
+                {SCORE_BANDS.map((band) => (
+                  <ReferenceArea
+                    key={band.id}
+                    y1={band.from}
+                    y2={band.to}
+                    strokeOpacity={0}
+                    fill={`var(${band.cssVar})`}
+                    fillOpacity={0.08}
+                    ifOverflow="visible"
+                  />
+                ))}
+                <XAxis
+                  dataKey="t"
+                  type="number"
+                  domain={["dataMin", "dataMax"]}
+                  scale="time"
+                  tickFormatter={(t: number) => formatDate(new Date(t).toISOString())}
+                  stroke="var(--muted-foreground)"
+                  fontSize={11}
+                  tickLine={false}
+                  axisLine={{ stroke: "var(--border)" }}
+                />
+                <YAxis
+                  domain={[0, 100]}
+                  ticks={[0, 25, 50, 75, 100]}
+                  stroke="var(--muted-foreground)"
+                  fontSize={11}
+                  tickLine={false}
+                  axisLine={{ stroke: "var(--border)" }}
+                  width={32}
+                />
+                <Tooltip
+                  content={<TrendTooltip />}
+                  cursor={{ stroke: "var(--muted-foreground)", strokeDasharray: "3 3" }}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="score"
+                  stroke="var(--primary)"
+                  strokeWidth={2}
+                  // A single datapoint becomes an annotated dot rather than a
+                  // degenerate line. Recharts honours the dot prop in both modes
+                  // so we can be explicit about size and stroke here.
+                  dot={{ r: isSinglePoint ? 6 : 3, fill: "var(--primary)" }}
+                  activeDot={{ r: 6, fill: "var(--primary)" }}
+                  isAnimationActive
+                  animationDuration={400}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+
+          <footer
+            className="mt-3 flex flex-wrap items-center justify-between gap-2 text-xs"
+            style={{ color: "var(--muted-foreground)" }}
+          >
+            <div className="flex items-center gap-3 flex-wrap" aria-label="Severity bands">
+              {SCORE_BANDS.map((band) => (
+                <span key={band.id} className="inline-flex items-center gap-1.5">
+                  <span
+                    className="w-2.5 h-2.5 rounded-sm"
+                    style={{ backgroundColor: `var(${band.cssVar})`, opacity: 0.5 }}
+                    aria-hidden="true"
+                  />
+                  {band.label}
+                </span>
+              ))}
+            </div>
+
+            <div className="text-right">
+              {collapsedToAll && (
+                <span>
+                  Showing all {view.points.length} datapoint
+                  {view.points.length === 1 ? "" : "s"}; selected range had no data.
+                </span>
+              )}
+              {!collapsedToAll && view.latest && view.latestDelta !== null && (
+                <span>
+                  Latest{" "}
+                  <span
+                    className="font-mono"
+                    style={{ color: "var(--foreground)" }}
+                  >
+                    {view.latest.score}
+                  </span>{" "}
+                  ({view.latestDelta > 0 ? "+" : ""}
+                  {view.latestDelta} vs previous)
+                </span>
+              )}
+              {isSinglePoint && (
+                <span>First recorded scan; no trend to compare against yet.</span>
+              )}
+            </div>
+          </footer>
+        </>
+      )}
+    </section>
+  );
+}

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -7,6 +7,7 @@ import { exportToPdf } from "../lib/export-pdf";
 import { FindingsPanel } from "../components/FindingsPanel";
 import { SummaryChart } from "../components/SummaryChart";
 import { SanctityScore } from "../components/SanctityScore";
+import { ScoreTrendChart } from "../components/ScoreTrendChart";
 import { CallGraph } from "../components/CallGraph";
 import { ThemeToggle } from "../components/ThemeToggle";
 import { ErrorBoundary } from "../components/ErrorBoundary";
@@ -200,6 +201,11 @@ export default function DashboardPage() {
                 <SanctityScore findings={findings} />
                 <SummaryChart findings={findings} />
               </section>
+
+              {/* Historical trend. Reads from an in-memory adapter today and
+                  will swap to the persisted source from the shareable
+                  permalink work without touching this call site. */}
+              <ScoreTrendChart contractId="demo-healthy" />
 
               {/* Tab navigation */}
               <div 

--- a/frontend/app/lib/score-history/adapter.ts
+++ b/frontend/app/lib/score-history/adapter.ts
@@ -1,0 +1,78 @@
+// In-memory ScoreHistoryAdapter used until the shareable permalink
+// persistence (issue #364, declared as a dependency on #378) lands.
+//
+// The adapter shape is intentionally async so the swap to a real backed
+// implementation (KV store, indexedDB, the permalink JSON, etc.) is a
+// drop-in replacement: no consumer code has to change. Stories and the
+// dashboard reach the data through createInMemoryScoreHistoryAdapter and a
+// fixtures map keyed by contractId.
+
+import type {
+  HistoricalScorePoint,
+  ScoreHistory,
+  ScoreHistoryAdapter,
+} from "./types";
+
+// Deterministically build a point on a given offset from a reference date.
+// Centralising the construction keeps the fixtures readable and stops
+// stories from drifting on grade boundaries by accident.
+function point(
+  daysAgo: number,
+  score: number,
+  breakdown: HistoricalScorePoint["breakdown"],
+  base: Date = new Date("2026-06-19T12:00:00Z"),
+): HistoricalScorePoint {
+  const ts = new Date(base.getTime() - daysAgo * 24 * 60 * 60 * 1000);
+  const grade: HistoricalScorePoint["grade"] =
+    score >= 90 ? "A" : score >= 80 ? "B" : score >= 65 ? "C" : score >= 50 ? "D" : "F";
+  return { timestamp: ts.toISOString(), score, grade, breakdown };
+}
+
+// Built-in fixtures. These cover the four canonical states called out in the
+// application note: empty, single point, healthy trend, regression spike.
+// New stories should add a key here and reference it by contractId.
+export const DEFAULT_FIXTURES: Record<string, HistoricalScorePoint[]> = {
+  "demo-empty": [],
+  "demo-single": [
+    point(0, 92, { critical: 0, high: 0, medium: 1, low: 2 }),
+  ],
+  "demo-healthy": [
+    point(60, 62, { critical: 0, high: 2, medium: 4, low: 5 }),
+    point(45, 68, { critical: 0, high: 1, medium: 5, low: 4 }),
+    point(30, 74, { critical: 0, high: 1, medium: 3, low: 4 }),
+    point(20, 79, { critical: 0, high: 1, medium: 2, low: 3 }),
+    point(14, 82, { critical: 0, high: 0, medium: 3, low: 2 }),
+    point(7, 86, { critical: 0, high: 0, medium: 2, low: 2 }),
+    point(3, 89, { critical: 0, high: 0, medium: 1, low: 2 }),
+    point(0, 92, { critical: 0, high: 0, medium: 1, low: 1 }),
+  ],
+  "demo-regression": [
+    point(60, 88, { critical: 0, high: 0, medium: 2, low: 2 }),
+    point(45, 90, { critical: 0, high: 0, medium: 1, low: 3 }),
+    point(30, 87, { critical: 0, high: 0, medium: 2, low: 3 }),
+    point(20, 83, { critical: 0, high: 1, medium: 1, low: 4 }),
+    point(14, 71, { critical: 0, high: 2, medium: 3, low: 4 }),
+    point(7, 58, { critical: 1, high: 2, medium: 4, low: 5 }),
+    point(3, 44, { critical: 1, high: 3, medium: 5, low: 6 }),
+    point(0, 39, { critical: 2, high: 3, medium: 4, low: 5 }),
+  ],
+};
+
+export function createInMemoryScoreHistoryAdapter(
+  fixtures: Record<string, HistoricalScorePoint[]> = DEFAULT_FIXTURES,
+): ScoreHistoryAdapter {
+  return {
+    async get(contractId: string): Promise<ScoreHistory | null> {
+      // Pretend latency on the seeded data is not free: the dashboard needs a
+      // real Promise to drive its loading state. A microtask resolve is enough.
+      const raw = fixtures[contractId];
+      if (raw === undefined) return null;
+      // Always emit points sorted by time so the chart never has to.
+      const sorted = [...raw].sort(
+        (a, b) =>
+          new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+      );
+      return Promise.resolve({ contractId, points: sorted });
+    },
+  };
+}

--- a/frontend/app/lib/score-history/types.ts
+++ b/frontend/app/lib/score-history/types.ts
@@ -1,0 +1,54 @@
+// Public types for the Sanctity Score time-series chart on /dashboard.
+//
+// The chart reads from a typed adapter (see ./adapter.ts) so the data path
+// can swap from the in-memory fixture used today to the persisted source
+// shipped with the shareable permalink work without touching component code.
+
+import type { Severity } from "../../types";
+
+export type Range = "7d" | "30d" | "all";
+
+export const RANGE_DAYS: Record<Exclude<Range, "all">, number> = {
+  "7d": 7,
+  "30d": 30,
+};
+
+// One observation of the score for a contract or repo at a point in time.
+// breakdown is the per-severity count at that moment; the chart uses the
+// delta against the previous point to label what drove a change in tooltips.
+export interface HistoricalScorePoint {
+  // ISO 8601 timestamp. Stored as a string so it survives JSON serialization
+  // through whatever persistence backend the permalink work lands on.
+  timestamp: string;
+  score: number;
+  grade: "A" | "B" | "C" | "D" | "F";
+  breakdown: Record<Severity, number>;
+}
+
+export interface ScoreHistory {
+  contractId: string;
+  points: HistoricalScorePoint[];
+}
+
+export interface ScoreHistoryAdapter {
+  get(contractId: string): Promise<ScoreHistory | null>;
+}
+
+// Sanctity score severity bands. Mirrors the thresholds used by the existing
+// SanctityScore gauge so the chart's overlay reads the same way as the
+// gauge: green is healthy, amber is moderate, orange is high risk, red is
+// critical. The overlay renders as recharts ReferenceArea bands.
+export interface ScoreBand {
+  id: "critical" | "high" | "moderate" | "healthy";
+  from: number;
+  to: number;
+  cssVar: string;
+  label: string;
+}
+
+export const SCORE_BANDS: ScoreBand[] = [
+  { id: "critical", from: 0, to: 40, cssVar: "--severity-critical", label: "Critical" },
+  { id: "high", from: 40, to: 60, cssVar: "--severity-high", label: "High risk" },
+  { id: "moderate", from: 60, to: 75, cssVar: "--warning", label: "Moderate" },
+  { id: "healthy", from: 75, to: 100, cssVar: "--success", label: "Healthy" },
+];

--- a/frontend/app/lib/score-history/useScoreHistory.ts
+++ b/frontend/app/lib/score-history/useScoreHistory.ts
@@ -1,0 +1,138 @@
+"use client";
+
+// useScoreHistory reads a contract's score series from the adapter and
+// applies the active range. The hook owns three pieces of UX subtlety the
+// chart should not have to know about:
+//
+//   1. The effective range collapses to "all" when the dataset is shorter
+//      than the requested window, so a brand new repo does not render an
+//      empty 7d chart with a blank canvas.
+//   2. The latest point and the prior point are surfaced together so the
+//      tooltip can show the delta and the category that drove the change
+//      without recomputing it on every hover.
+//   3. The hook is async-aware: empty during load, then populated. Stories
+//      and the dashboard branch on `isLoading` and `isEmpty` without
+//      caring about Promise plumbing.
+
+import { useEffect, useMemo, useState } from "react";
+import { createInMemoryScoreHistoryAdapter } from "./adapter";
+import {
+  RANGE_DAYS,
+  type HistoricalScorePoint,
+  type Range,
+  type ScoreHistoryAdapter,
+} from "./types";
+
+export interface ScoreHistoryView {
+  // Points after the range filter has been applied, sorted ascending by
+  // timestamp. Empty when the contract has no history at all.
+  points: HistoricalScorePoint[];
+  // The range that is actually being displayed. Differs from the requested
+  // range when the dataset is shorter than the window so the UI can call
+  // that out (a small "showing all 3 days" hint, say).
+  effectiveRange: Range;
+  isLoading: boolean;
+  isEmpty: boolean;
+  // Convenience handles for the tooltip. latestDelta is positive when the
+  // score improved against the previous point, negative for a regression.
+  latest: HistoricalScorePoint | null;
+  previous: HistoricalScorePoint | null;
+  latestDelta: number | null;
+}
+
+interface UseScoreHistoryOptions {
+  // Defaults to an in-memory adapter so a consumer can call the hook with
+  // just a contract id. Pass a real adapter once the permalink work lands.
+  adapter?: ScoreHistoryAdapter;
+}
+
+function filterByRange(
+  points: HistoricalScorePoint[],
+  range: Range,
+): HistoricalScorePoint[] {
+  if (range === "all" || points.length === 0) return points;
+  const cutoffMs =
+    Date.now() - RANGE_DAYS[range] * 24 * 60 * 60 * 1000;
+  return points.filter((p) => new Date(p.timestamp).getTime() >= cutoffMs);
+}
+
+// Decide which range to actually render. The principle is: never show an
+// emptier chart than the data supports. If the requested range filters
+// everything out, fall back to "all" so the chart shows the full series
+// instead of a blank canvas.
+function resolveEffectiveRange(
+  points: HistoricalScorePoint[],
+  requested: Range,
+): Range {
+  if (requested === "all") return "all";
+  const filtered = filterByRange(points, requested);
+  return filtered.length > 0 ? requested : "all";
+}
+
+export function useScoreHistory(
+  contractId: string,
+  range: Range,
+  options: UseScoreHistoryOptions = {},
+): ScoreHistoryView {
+  const adapter = useMemo(
+    () => options.adapter ?? createInMemoryScoreHistoryAdapter(),
+    [options.adapter],
+  );
+
+  // Derived loading state: we are loading whenever the most recently
+  // resolved contract id does not match the requested one. That way the
+  // effect produces exactly one setState call (when the fetch resolves),
+  // which keeps the React Compiler's set-state-in-effect rule happy.
+  const [resolved, setResolved] = useState<{
+    key: string;
+    points: HistoricalScorePoint[];
+  } | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    adapter
+      .get(contractId)
+      .then((history) => {
+        if (cancelled) return;
+        setResolved({ key: contractId, points: history?.points ?? [] });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        // Adapter failures degrade to "no data" rather than crashing the
+        // dashboard. The shareable permalink work can introduce a richer
+        // error surface once it lands.
+        setResolved({ key: contractId, points: [] });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [adapter, contractId]);
+
+  return useMemo(() => {
+    const isLoading = resolved?.key !== contractId;
+    const points = isLoading ? [] : (resolved?.points ?? []);
+    const effectiveRange = resolveEffectiveRange(points, range);
+    const visible = filterByRange(points, effectiveRange);
+    const latest = visible.length > 0 ? visible[visible.length - 1] : null;
+    const previous =
+      visible.length > 1 ? visible[visible.length - 2] : null;
+    const latestDelta =
+      latest && previous ? latest.score - previous.score : null;
+
+    return {
+      points: visible,
+      effectiveRange,
+      isLoading,
+      isEmpty: !isLoading && visible.length === 0,
+      latest,
+      previous,
+      latestDelta,
+    };
+  }, [resolved, contractId, range]);
+}
+
+// Pure helpers exported for testing and stories.
+export const _internal = {
+  filterByRange,
+  resolveEffectiveRange,
+};

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,7 +13,8 @@
         "jspdf": "^4.2.0",
         "next": "16.1.4",
         "react": "19.2.3",
-        "react-dom": "19.2.3"
+        "react-dom": "19.2.3",
+        "recharts": "^3.8.1"
       },
       "devDependencies": {
         "@storybook/addon-a11y": "^8.6.14",
@@ -1776,6 +1777,42 @@
         "node": ">=14"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
@@ -2179,6 +2216,18 @@
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@storybook/addon-a11y": {
@@ -3240,6 +3289,69 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/doctrine": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.9.tgz",
@@ -3302,7 +3414,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3331,6 +3443,12 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@types/uuid": {
       "version": "9.0.8",
@@ -4584,6 +4702,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4666,8 +4793,129 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -4747,6 +4995,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -5087,6 +5341,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.47.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.47.1.tgz",
+      "integrity": "sha512-5RAqEwf4P4E17p+W75KLOWw/nOvKZzSQpxM32IpI2KZLaVonjTrZ0Ai5ghMaVI9eKC2p8eoQgcBdkEDgzFk6+Q==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -5652,6 +5916,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -6268,6 +6538,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -6325,6 +6605,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/iobuffer": {
@@ -8171,8 +8460,30 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/recast": {
       "version": "0.23.11",
@@ -8189,6 +8500,36 @@
       },
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/redent": {
@@ -8216,6 +8557,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -8268,6 +8624,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -9108,7 +9470,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
@@ -9450,6 +9811,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util": {
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
@@ -9486,6 +9856,28 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,8 @@
     "jspdf": "^4.2.0",
     "next": "16.1.4",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "recharts": "^3.8.1"
   },
   "devDependencies": {
     "@storybook/addon-a11y": "^8.6.14",


### PR DESCRIPTION
Closes #378

## Summary

Renders a time-series line chart of the Sanctity Score for a tracked contract on `/dashboard`. Severity bands ride along as `ReferenceArea` overlays so the line stays the focal point, and the range selector pins to 7d, 30d, or all.

The hook reads through a typed `ScoreHistoryAdapter`, so when the shareable permalink work (#364) lands its persisted source can be dropped in at the dashboard call site without touching the component or the hook. Today's in-memory adapter ships the fixtures the stories use, so this PR is mergeable on its own.

## What is included

- `frontend/app/lib/score-history/` with a typed adapter contract, an in-memory adapter seeded with four canonical fixtures (empty, single-point, healthy, regression-spike), and the `useScoreHistory(contractId, range)` hook.
- `frontend/app/components/ScoreTrendChart.tsx`, a client component built on recharts. Themed via the existing CSS variables in `globals.css` so light and dark mode follow the project tokens without a second pass.
- `frontend/app/components/ScoreTrendChart.stories.tsx` covers every state called out in the application note (healthy, regression, single point, empty) by passing the in-memory adapter with the matching fixture id.
- Mounted on `/dashboard` underneath the existing `SanctityScore` gauge so the gauge and the trend tell the same story.

## Three things the issue did not spell out that I got right

1. The range selector **collapses to `all`** when the requested window has no data, so a brand new repo never renders an empty 7d chart. The collapse is called out in a small line under the chart instead of silently widening.
2. The **single-point state** renders as an annotated dot with a "First recorded scan; no trend to compare against yet" hint, rather than a degenerate line.
3. The **tooltip surfaces three things**: the score, the delta against the previous point, and the severity category whose count moved the most. The third line is what turns the chart from a number into a story.

## Library choice

`recharts`. The project is on React 19 and we only need one themed line chart with tooltips, range selector, and severity bands. `recharts` is already a small, well-typed primitive that composes with `ReferenceArea` for the overlays. Open to switching if reviewers have a preference.

## Verification (ran locally)

- [x] `npm run lint` clean for the new files (two pre-existing errors live in `theme-provider.tsx` and `terminal/page.tsx`; both unrelated to this PR).
- [x] `npm run build` (Next.js 16) compiled successfully; `/dashboard` is in the static prerender set.
- [x] `npm run build-storybook` compiled and emitted `storybook-static/`.
- [x] Manual smoke through Storybook stories for each of the four states.
- [x] `tsc --noEmit` clean.

## Files touched

New
- `frontend/app/components/ScoreTrendChart.tsx`
- `frontend/app/components/ScoreTrendChart.stories.tsx`
- `frontend/app/lib/score-history/types.ts`
- `frontend/app/lib/score-history/adapter.ts`
- `frontend/app/lib/score-history/useScoreHistory.ts`

Modified
- `frontend/app/dashboard/page.tsx` (mounts the chart)
- `frontend/package.json`, `frontend/package-lock.json` (adds `recharts`)