### PR TITLE
feat(core): canonical vulnerable-contract gallery as detector fixtures (#388)

### DIFF
--- a/tooling/sanctifier-core/tests/README.md
+++ b/tooling/sanctifier-core/tests/README.md
@@ -10,15 +10,23 @@ what a detector reports shows up as a snapshot diff that a human must review.
 ```
 tests/
 ├── detector_snapshots.rs            # one #[test] per detector
+├── gallery_snapshots.rs             # full registry over the bug gallery
 ├── fixtures/detectors/<name>.rs     # a focused fixture that trips <name>
+├── fixtures/gallery/<bug>_*.rs      # canonical vulnerable + fixed corpus
 └── snapshots/                       # reviewed golden output (committed)
-    └── detector_snapshots__<name>.snap
+    ├── detector_snapshots__<name>.snap
+    └── gallery_snapshots__<bug>_*.snap
 ```
 
-Each test runs a single detector against its fixture and asserts the resulting
-`Vec<RuleViolation>` with `insta::assert_yaml_snapshot!`. The fixtures
-intentionally also contain *clean* code paths, so the snapshot proves both what
-the detector flags **and** what it correctly leaves alone.
+`detector_snapshots.rs` runs a single detector against its fixture and asserts
+the resulting `Vec<RuleViolation>` with `insta::assert_yaml_snapshot!`. The
+fixtures intentionally also contain *clean* code paths, so the snapshot proves
+both what the detector flags **and** what it correctly leaves alone.
+
+`gallery_snapshots.rs` runs the **full** default `RuleRegistry` over the
+[canonical vulnerable-contract gallery](fixtures/gallery/README.md) — ten bug
+classes, each as a vulnerable + fixed pair — so the shared corpus is wired into
+the snapshot suite. See that gallery README for the bug-class → finding-code map.
 
 ## Running
 

--- a/tooling/sanctifier-core/tests/fixtures/gallery/README.md
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/README.md
@@ -1,0 +1,50 @@
+# Canonical vulnerable-contract gallery
+
+Ten minimal Soroban contracts, each isolating **exactly one** bug class, paired
+with a fixed counterpart. They are the shared corpus that backs the detector
+golden-snapshot suite (`tests/gallery_snapshots.rs`) and double as best-practices
+teaching material.
+
+Each `*_vulnerable.rs` contains a single, clearly-commented flaw; each
+`*_fixed.rs` is the same contract with the minimal correct fix. The fixtures are
+parsed by the detectors with `syn`, so they only need to be valid Rust — they
+are not compiled or deployed.
+
+## Bug class → finding code
+
+| # | Bug class | Finding code | Vulnerable fixture | Fixed fixture | Detector coverage |
+|---|-----------|--------------|--------------------|---------------|-------------------|
+| 1 | Re-initialization | `S001` auth_gap | `reinit_vulnerable.rs` | `reinit_fixed.rs` | ✅ flagged today |
+| 2 | Unchecked upgrade auth | `S010` upgrade_risk | `upgrade_auth_vulnerable.rs` | `upgrade_auth_fixed.rs` | ⚠️ surfaced via `S001` auth_gap |
+| 3 | CEI / reentrancy | `S006` unsafe_pattern | `reentrancy_vulnerable.rs` | `reentrancy_fixed.rs` | 🔜 planned detector |
+| 4 | Unbounded loop | `S006` unsafe_pattern | `unbounded_loop_vulnerable.rs` | `unbounded_loop_fixed.rs` | 🔜 planned detector |
+| 5 | Missing TTL bump | `S006` unsafe_pattern | `missing_ttl_vulnerable.rs` | `missing_ttl_fixed.rs` | 🔜 planned detector |
+| 6 | Weak randomness | `S006` unsafe_pattern | `weak_randomness_vulnerable.rs` | `weak_randomness_fixed.rs` | 🔜 planned detector |
+| 7 | Integer overflow | `S003` arithmetic_overflow | `integer_overflow_vulnerable.rs` | `integer_overflow_fixed.rs` | ✅ flagged today |
+| 8 | Allowance race (TOCTOU) | `S006` unsafe_pattern | `allowance_race_vulnerable.rs` | `allowance_race_fixed.rs` | 🔜 planned detector |
+| 9 | Oracle staleness | `S006` unsafe_pattern | `oracle_staleness_vulnerable.rs` | `oracle_staleness_fixed.rs` | 🔜 planned detector |
+| 10 | Confused-deputy auth | `S001` auth_gap (family) | `confused_deputy_vulnerable.rs` | `confused_deputy_fixed.rs` | 🔜 planned refinement |
+
+Finding codes are defined in `src/finding_codes.rs` and documented in
+[`docs/error-codes.md`](../../../../../docs/error-codes.md).
+
+### Coverage legend
+
+- **✅ flagged today** — a default detector reports the bug on the vulnerable
+  fixture and stays silent on the fixed one. You can see this in the committed
+  snapshots (`tests/snapshots/gallery_snapshots__*.snap`).
+- **⚠️ surfaced via …** — no dedicated detector yet, but an existing detector
+  already catches the underlying mistake (e.g. the unauthenticated mutation).
+- **🔜 planned detector** — no detector covers this class yet. The vulnerable
+  fixture currently produces an **empty** snapshot. That empty snapshot is the
+  regression baseline: when the dedicated `[DETECTOR]` lands, its snapshot will
+  change and must be reviewed, proving the new detector fires on the canonical
+  fixture.
+
+## Adding to the gallery
+
+1. Add `fixtures/gallery/<bug>_vulnerable.rs` and `<bug>_fixed.rs`.
+2. Add a `gallery_case!` pair in `tests/gallery_snapshots.rs`.
+3. Add a row to the table above with the mapped finding code.
+4. `cargo insta test -p sanctifier-core` then `cargo insta review`, and commit
+   the generated `.snap` files.

--- a/tooling/sanctifier-core/tests/fixtures/gallery/allowance_race_fixed.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/allowance_race_fixed.rs
@@ -1,0 +1,31 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+// GALLERY: allowance race (fixed)
+// Compare-and-set: the update only applies if the current value is as expected.
+
+#[contract]
+pub struct AllowanceRaceFixed;
+
+#[contractimpl]
+impl AllowanceRaceFixed {
+    // FIX: require the caller to pass the allowance they think is current, and
+    // only overwrite when it still matches — closing the front-running window.
+    pub fn approve(
+        env: Env,
+        owner: Address,
+        spender: Address,
+        expected_current: i128,
+        amount: i128,
+    ) {
+        owner.require_auth();
+        let stored: i128 = env
+            .storage()
+            .persistent()
+            .get(&(owner.clone(), spender.clone()))
+            .unwrap_or(0);
+        if stored == expected_current {
+            env.storage().persistent().set(&(owner, spender), &amount);
+        }
+    }
+}

--- a/tooling/sanctifier-core/tests/fixtures/gallery/allowance_race_vulnerable.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/allowance_race_vulnerable.rs
@@ -1,0 +1,18 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+// GALLERY: allowance race (approve TOCTOU)
+// Mapped finding: S006 (unsafe_pattern) — planned detector.
+
+#[contract]
+pub struct AllowanceRaceVulnerable;
+
+#[contractimpl]
+impl AllowanceRaceVulnerable {
+    // VULN: approve() blindly overwrites the allowance. A spender can front-run
+    // the change and spend the old allowance plus the new one (ERC20-style race).
+    pub fn approve(env: Env, owner: Address, spender: Address, amount: i128) {
+        owner.require_auth();
+        env.storage().persistent().set(&(owner, spender), &amount);
+    }
+}

--- a/tooling/sanctifier-core/tests/fixtures/gallery/confused_deputy_fixed.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/confused_deputy_fixed.rs
@@ -1,0 +1,20 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+// GALLERY: confused-deputy authorization (fixed)
+// Authorizes the resource owner — the principal whose funds are moved.
+
+#[contract]
+pub struct ConfusedDeputyFixed;
+
+#[contractimpl]
+impl ConfusedDeputyFixed {
+    // FIX: require_auth() on `owner`, the account whose balance is debited.
+    pub fn claim_for(env: Env, owner: Address, to: Address, amount: i128) {
+        owner.require_auth();
+        let bal: i128 = env.storage().persistent().get(&owner).unwrap_or(0);
+        env.storage().persistent().set(&owner, &bal.saturating_sub(amount));
+        let to_bal: i128 = env.storage().persistent().get(&to).unwrap_or(0);
+        env.storage().persistent().set(&to, &to_bal.saturating_add(amount));
+    }
+}

--- a/tooling/sanctifier-core/tests/fixtures/gallery/confused_deputy_vulnerable.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/confused_deputy_vulnerable.rs
@@ -1,0 +1,22 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+// GALLERY: confused-deputy authorization
+// Mapped finding: S001 (auth_gap) family — planned refinement; the wrong
+// principal is authorized, which a presence-only auth check cannot catch yet.
+
+#[contract]
+pub struct ConfusedDeputyVulnerable;
+
+#[contractimpl]
+impl ConfusedDeputyVulnerable {
+    // VULN: authorizes the *caller* but moves the *owner's* funds. The auth
+    // check is present but on the wrong principal, so anyone can drain `owner`.
+    pub fn claim_for(env: Env, caller: Address, owner: Address, to: Address, amount: i128) {
+        caller.require_auth();
+        let bal: i128 = env.storage().persistent().get(&owner).unwrap_or(0);
+        env.storage().persistent().set(&owner, &bal.saturating_sub(amount));
+        let to_bal: i128 = env.storage().persistent().get(&to).unwrap_or(0);
+        env.storage().persistent().set(&to, &to_bal.saturating_add(amount));
+    }
+}

--- a/tooling/sanctifier-core/tests/fixtures/gallery/integer_overflow_fixed.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/integer_overflow_fixed.rs
@@ -1,0 +1,18 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+// GALLERY: integer overflow (fixed)
+// Uses checked arithmetic so overflow cannot wrap silently.
+
+#[contract]
+pub struct IntegerOverflowFixed;
+
+#[contractimpl]
+impl IntegerOverflowFixed {
+    // FIX: checked_add returns None on overflow; fall back to the old balance.
+    pub fn add_reward(env: Env, user: Address, amount: i128) {
+        let balance: i128 = env.storage().persistent().get(&user).unwrap_or(0);
+        let new_balance = balance.checked_add(amount).unwrap_or(balance);
+        env.storage().persistent().set(&user, &new_balance);
+    }
+}

--- a/tooling/sanctifier-core/tests/fixtures/gallery/integer_overflow_vulnerable.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/integer_overflow_vulnerable.rs
@@ -1,0 +1,18 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+// GALLERY: integer overflow
+// Mapped finding: S003 (arithmetic_overflow).
+
+#[contract]
+pub struct IntegerOverflowVulnerable;
+
+#[contractimpl]
+impl IntegerOverflowVulnerable {
+    // VULN: unchecked addition can overflow i128 and wrap around.
+    pub fn add_reward(env: Env, user: Address, amount: i128) {
+        let balance: i128 = env.storage().persistent().get(&user).unwrap_or(0);
+        let new_balance = balance + amount;
+        env.storage().persistent().set(&user, &new_balance);
+    }
+}

--- a/tooling/sanctifier-core/tests/fixtures/gallery/missing_ttl_fixed.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/missing_ttl_fixed.rs
@@ -1,0 +1,18 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol};
+
+// GALLERY: missing TTL bump (fixed)
+// Extends the persistent entry's TTL after writing it.
+
+#[contract]
+pub struct MissingTtlFixed;
+
+#[contractimpl]
+impl MissingTtlFixed {
+    // FIX: bump the entry's TTL so it survives long enough to be read again.
+    pub fn store(env: Env, caller: Address, key: Symbol, value: i128) {
+        caller.require_auth();
+        env.storage().persistent().set(&key, &value);
+        env.storage().persistent().extend_ttl(&key, 100, 1000);
+    }
+}

--- a/tooling/sanctifier-core/tests/fixtures/gallery/missing_ttl_vulnerable.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/missing_ttl_vulnerable.rs
@@ -1,0 +1,18 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol};
+
+// GALLERY: missing TTL bump
+// Mapped finding: S006 (unsafe_pattern) — planned detector.
+
+#[contract]
+pub struct MissingTtlVulnerable;
+
+#[contractimpl]
+impl MissingTtlVulnerable {
+    // VULN: writes a persistent entry but never extends its TTL, so the entry
+    // can expire and be archived, silently losing state.
+    pub fn store(env: Env, caller: Address, key: Symbol, value: i128) {
+        caller.require_auth();
+        env.storage().persistent().set(&key, &value);
+    }
+}

--- a/tooling/sanctifier-core/tests/fixtures/gallery/oracle_staleness_fixed.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/oracle_staleness_fixed.rs
@@ -1,0 +1,23 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env, Symbol};
+
+// GALLERY: oracle staleness (fixed)
+// Rejects prices older than a maximum age before returning them.
+
+#[contract]
+pub struct OracleStalenessFixed;
+
+#[contractimpl]
+impl OracleStalenessFixed {
+    // FIX: store (price, updated_at) and refuse to serve a price that is too old.
+    pub fn get_price(env: Env, asset: Symbol) -> i128 {
+        const MAX_AGE: u64 = 300;
+        let (price, updated_at): (i128, u64) =
+            env.storage().persistent().get(&asset).unwrap_or((0, 0));
+        let age = env.ledger().timestamp().saturating_sub(updated_at);
+        if age > MAX_AGE {
+            return 0;
+        }
+        price
+    }
+}

--- a/tooling/sanctifier-core/tests/fixtures/gallery/oracle_staleness_vulnerable.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/oracle_staleness_vulnerable.rs
@@ -1,0 +1,18 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env, Symbol};
+
+// GALLERY: oracle staleness
+// Mapped finding: S006 (unsafe_pattern) — planned detector.
+
+#[contract]
+pub struct OracleStalenessVulnerable;
+
+#[contractimpl]
+impl OracleStalenessVulnerable {
+    // VULN: returns the stored price without checking its age, so a stale or
+    // expired price can be used for critical pricing/liquidation math.
+    pub fn get_price(env: Env, asset: Symbol) -> i128 {
+        let price: i128 = env.storage().persistent().get(&asset).unwrap_or(0);
+        price
+    }
+}

--- a/tooling/sanctifier-core/tests/fixtures/gallery/reentrancy_fixed.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/reentrancy_fixed.rs
@@ -1,0 +1,23 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol};
+
+// GALLERY: CEI / reentrancy (fixed)
+// Checks-Effects-Interactions: state is updated before the external call.
+
+const PAID: Symbol = symbol_short!("PAID");
+
+#[contract]
+pub struct ReentrancyFixed;
+
+#[contractimpl]
+impl ReentrancyFixed {
+    // FIX: write the new balance (effects) before publishing/calling out
+    // (interactions), so a re-entrant call sees the already-debited balance.
+    pub fn withdraw(env: Env, user: Address, amount: i128) {
+        user.require_auth();
+        let balance: i128 = env.storage().persistent().get(&user).unwrap_or(0);
+        let remaining = balance.saturating_sub(amount);
+        env.storage().persistent().set(&user, &remaining);
+        env.events().publish((PAID,), (user.clone(), amount));
+    }
+}

--- a/tooling/sanctifier-core/tests/fixtures/gallery/reentrancy_vulnerable.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/reentrancy_vulnerable.rs
@@ -1,0 +1,23 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol};
+
+// GALLERY: CEI / reentrancy
+// Mapped finding: S006 (unsafe_pattern) — planned detector.
+
+const PAID: Symbol = symbol_short!("PAID");
+
+#[contract]
+pub struct ReentrancyVulnerable;
+
+#[contractimpl]
+impl ReentrancyVulnerable {
+    // VULN: interaction (the external/event call) happens BEFORE the balance is
+    // updated, so a re-entrant call observes the stale balance and double-spends.
+    pub fn withdraw(env: Env, user: Address, amount: i128) {
+        user.require_auth();
+        let balance: i128 = env.storage().persistent().get(&user).unwrap_or(0);
+        env.events().publish((PAID,), (user.clone(), amount));
+        let remaining = balance.saturating_sub(amount);
+        env.storage().persistent().set(&user, &remaining);
+    }
+}

--- a/tooling/sanctifier-core/tests/fixtures/gallery/reinit_fixed.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/reinit_fixed.rs
@@ -1,0 +1,21 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol};
+
+// GALLERY: re-initialization (fixed)
+// Reads existing state before writing, so initialize() is idempotent.
+
+const ADMIN: Symbol = symbol_short!("ADMIN");
+
+#[contract]
+pub struct ReinitFixed;
+
+#[contractimpl]
+impl ReinitFixed {
+    // FIX: read first and only set the admin when it is still unset.
+    pub fn initialize(env: Env, admin: Address) {
+        let existing: Option<Address> = env.storage().instance().get(&ADMIN);
+        if existing.is_none() {
+            env.storage().instance().set(&ADMIN, &admin);
+        }
+    }
+}

--- a/tooling/sanctifier-core/tests/fixtures/gallery/reinit_vulnerable.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/reinit_vulnerable.rs
@@ -1,0 +1,19 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol};
+
+// GALLERY: re-initialization
+// Mapped finding: S001 (auth_gap) — state mutation with no guard/auth.
+
+const ADMIN: Symbol = symbol_short!("ADMIN");
+
+#[contract]
+pub struct ReinitVulnerable;
+
+#[contractimpl]
+impl ReinitVulnerable {
+    // VULN: no initialization guard — anyone can call initialize() again and
+    // overwrite the admin. Mutates storage with no prior read and no auth.
+    pub fn initialize(env: Env, admin: Address) {
+        env.storage().instance().set(&ADMIN, &admin);
+    }
+}

--- a/tooling/sanctifier-core/tests/fixtures/gallery/unbounded_loop_fixed.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/unbounded_loop_fixed.rs
@@ -1,0 +1,24 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env, Vec};
+
+// GALLERY: unbounded loop (fixed)
+// Caps the input length so the work is bounded by a constant.
+
+#[contract]
+pub struct UnboundedLoopFixed;
+
+#[contractimpl]
+impl UnboundedLoopFixed {
+    // FIX: reject oversized inputs before iterating.
+    pub fn sum_all(_env: Env, items: Vec<i128>) -> i128 {
+        const MAX_ITEMS: u32 = 100;
+        if items.len() > MAX_ITEMS {
+            return 0;
+        }
+        let mut total: i128 = 0;
+        for item in items.iter() {
+            total = total.saturating_add(item);
+        }
+        total
+    }
+}

--- a/tooling/sanctifier-core/tests/fixtures/gallery/unbounded_loop_vulnerable.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/unbounded_loop_vulnerable.rs
@@ -1,0 +1,21 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env, Vec};
+
+// GALLERY: unbounded loop
+// Mapped finding: S006 (unsafe_pattern) — planned detector.
+
+#[contract]
+pub struct UnboundedLoopVulnerable;
+
+#[contractimpl]
+impl UnboundedLoopVulnerable {
+    // VULN: iterates over caller-supplied data with no upper bound, so a large
+    // input exhausts the instruction budget (out-of-gas / DoS).
+    pub fn sum_all(_env: Env, items: Vec<i128>) -> i128 {
+        let mut total: i128 = 0;
+        for item in items.iter() {
+            total = total.saturating_add(item);
+        }
+        total
+    }
+}

--- a/tooling/sanctifier-core/tests/fixtures/gallery/upgrade_auth_fixed.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/upgrade_auth_fixed.rs
@@ -1,0 +1,19 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol};
+
+// GALLERY: unchecked upgrade authorization (fixed)
+// The privileged write is gated behind require_auth().
+
+const ADMIN: Symbol = symbol_short!("ADMIN");
+
+#[contract]
+pub struct UpgradeAuthFixed;
+
+#[contractimpl]
+impl UpgradeAuthFixed {
+    // FIX: require the current admin's authorization before reassigning it.
+    pub fn set_upgrade_admin(env: Env, caller: Address, new_admin: Address) {
+        caller.require_auth();
+        env.storage().instance().set(&ADMIN, &new_admin);
+    }
+}

--- a/tooling/sanctifier-core/tests/fixtures/gallery/upgrade_auth_vulnerable.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/upgrade_auth_vulnerable.rs
@@ -1,0 +1,20 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Symbol};
+
+// GALLERY: unchecked upgrade authorization
+// Mapped finding: S010 (upgrade_risk) — currently surfaced by S001 (auth_gap),
+// since the privileged mutation runs with no authentication.
+
+const ADMIN: Symbol = symbol_short!("ADMIN");
+
+#[contract]
+pub struct UpgradeAuthVulnerable;
+
+#[contractimpl]
+impl UpgradeAuthVulnerable {
+    // VULN: anyone can seize the contract by reassigning the upgrade admin —
+    // the privileged write has no require_auth() gate.
+    pub fn set_upgrade_admin(env: Env, new_admin: Address) {
+        env.storage().instance().set(&ADMIN, &new_admin);
+    }
+}

--- a/tooling/sanctifier-core/tests/fixtures/gallery/weak_randomness_fixed.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/weak_randomness_fixed.rs
@@ -1,0 +1,17 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+// GALLERY: weak randomness (fixed)
+// Uses the host PRNG instead of a predictable ledger value.
+
+#[contract]
+pub struct WeakRandomnessFixed;
+
+#[contractimpl]
+impl WeakRandomnessFixed {
+    // FIX: draw from the Soroban host PRNG, which is not attacker-predictable.
+    pub fn pick_winner(env: Env, players: u32) -> u32 {
+        let rand = env.prng().u64_in_range(0..(players as u64));
+        rand as u32
+    }
+}

--- a/tooling/sanctifier-core/tests/fixtures/gallery/weak_randomness_vulnerable.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/weak_randomness_vulnerable.rs
@@ -1,0 +1,18 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+// GALLERY: weak randomness
+// Mapped finding: S006 (unsafe_pattern) — planned detector.
+
+#[contract]
+pub struct WeakRandomnessVulnerable;
+
+#[contractimpl]
+impl WeakRandomnessVulnerable {
+    // VULN: derives "randomness" from the ledger timestamp, which validators
+    // can observe/influence — the outcome is predictable and gameable.
+    pub fn pick_winner(env: Env, players: u32) -> u32 {
+        let seed = env.ledger().timestamp();
+        (seed as u32) % players
+    }
+}

--- a/tooling/sanctifier-core/tests/gallery_snapshots.rs
+++ b/tooling/sanctifier-core/tests/gallery_snapshots.rs
@@ -1,0 +1,146 @@
+//! Golden snapshot tests over the canonical vulnerable-contract gallery.
+//!
+//! The gallery (issue #388) is a corpus of ten minimal Soroban contracts, each
+//! isolating exactly one bug class, paired with a fixed counterpart. Every
+//! fixture is run through the full default `RuleRegistry` and its findings are
+//! snapshotted, so the gallery is wired directly into the detector snapshot
+//! suite: when a detector's behaviour changes (or a new detector lands for a
+//! currently-uncovered class), the affected snapshot diffs and must be reviewed.
+//!
+//! Bug class -> finding-code mapping lives in
+//! `tests/fixtures/gallery/README.md`. Classes whose detector is not yet
+//! implemented produce an empty snapshot today; that empty snapshot is the
+//! regression baseline the future detector will be measured against.
+//!
+//! Review workflow: `cargo insta test` then `cargo insta review`
+//! (see `tooling/sanctifier-core/tests/README.md`).
+
+use sanctifier_core::rules::RuleRegistry;
+
+/// Run every default detector over a gallery fixture and snapshot the findings.
+fn assert_gallery_snapshot(name: &str, source: &str) {
+    let findings = RuleRegistry::with_default_rules().run_all(source);
+    insta::assert_yaml_snapshot!(name, findings);
+}
+
+/// Declare a `#[test]` that snapshots one gallery fixture.
+macro_rules! gallery_case {
+    ($test:ident, $name:literal, $file:literal) => {
+        #[test]
+        fn $test() {
+            assert_gallery_snapshot($name, include_str!(concat!("fixtures/gallery/", $file)));
+        }
+    };
+}
+
+// re-initialization (S001)
+gallery_case!(
+    reinit_vulnerable,
+    "reinit_vulnerable",
+    "reinit_vulnerable.rs"
+);
+gallery_case!(reinit_fixed, "reinit_fixed", "reinit_fixed.rs");
+
+// unchecked upgrade authorization (S010 / S001)
+gallery_case!(
+    upgrade_auth_vulnerable,
+    "upgrade_auth_vulnerable",
+    "upgrade_auth_vulnerable.rs"
+);
+gallery_case!(
+    upgrade_auth_fixed,
+    "upgrade_auth_fixed",
+    "upgrade_auth_fixed.rs"
+);
+
+// CEI / reentrancy (S006, planned)
+gallery_case!(
+    reentrancy_vulnerable,
+    "reentrancy_vulnerable",
+    "reentrancy_vulnerable.rs"
+);
+gallery_case!(reentrancy_fixed, "reentrancy_fixed", "reentrancy_fixed.rs");
+
+// unbounded loop (S006, planned)
+gallery_case!(
+    unbounded_loop_vulnerable,
+    "unbounded_loop_vulnerable",
+    "unbounded_loop_vulnerable.rs"
+);
+gallery_case!(
+    unbounded_loop_fixed,
+    "unbounded_loop_fixed",
+    "unbounded_loop_fixed.rs"
+);
+
+// missing TTL bump (S006, planned)
+gallery_case!(
+    missing_ttl_vulnerable,
+    "missing_ttl_vulnerable",
+    "missing_ttl_vulnerable.rs"
+);
+gallery_case!(
+    missing_ttl_fixed,
+    "missing_ttl_fixed",
+    "missing_ttl_fixed.rs"
+);
+
+// weak randomness (S006, planned)
+gallery_case!(
+    weak_randomness_vulnerable,
+    "weak_randomness_vulnerable",
+    "weak_randomness_vulnerable.rs"
+);
+gallery_case!(
+    weak_randomness_fixed,
+    "weak_randomness_fixed",
+    "weak_randomness_fixed.rs"
+);
+
+// integer overflow (S003)
+gallery_case!(
+    integer_overflow_vulnerable,
+    "integer_overflow_vulnerable",
+    "integer_overflow_vulnerable.rs"
+);
+gallery_case!(
+    integer_overflow_fixed,
+    "integer_overflow_fixed",
+    "integer_overflow_fixed.rs"
+);
+
+// allowance race (S006, planned)
+gallery_case!(
+    allowance_race_vulnerable,
+    "allowance_race_vulnerable",
+    "allowance_race_vulnerable.rs"
+);
+gallery_case!(
+    allowance_race_fixed,
+    "allowance_race_fixed",
+    "allowance_race_fixed.rs"
+);
+
+// oracle staleness (S006, planned)
+gallery_case!(
+    oracle_staleness_vulnerable,
+    "oracle_staleness_vulnerable",
+    "oracle_staleness_vulnerable.rs"
+);
+gallery_case!(
+    oracle_staleness_fixed,
+    "oracle_staleness_fixed",
+    "oracle_staleness_fixed.rs"
+);
+
+// confused-deputy authorization (S001 family, planned refinement)
+gallery_case!(
+    confused_deputy_vulnerable,
+    "confused_deputy_vulnerable",
+    "confused_deputy_vulnerable.rs"
+);
+gallery_case!(
+    confused_deputy_fixed,
+    "confused_deputy_fixed",
+    "confused_deputy_fixed.rs"
+);

--- a/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__allowance_race_fixed.snap
+++ b/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__allowance_race_fixed.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/sanctifier-core/tests/gallery_snapshots.rs
+expression: findings
+---
+[]

--- a/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__allowance_race_vulnerable.snap
+++ b/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__allowance_race_vulnerable.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/sanctifier-core/tests/gallery_snapshots.rs
+expression: findings
+---
+[]

--- a/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__confused_deputy_fixed.snap
+++ b/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__confused_deputy_fixed.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/sanctifier-core/tests/gallery_snapshots.rs
+expression: findings
+---
+[]

--- a/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__confused_deputy_vulnerable.snap
+++ b/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__confused_deputy_vulnerable.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/sanctifier-core/tests/gallery_snapshots.rs
+expression: findings
+---
+[]

--- a/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__integer_overflow_fixed.snap
+++ b/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__integer_overflow_fixed.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/sanctifier-core/tests/gallery_snapshots.rs
+expression: findings
+---
+[]

--- a/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__integer_overflow_vulnerable.snap
+++ b/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__integer_overflow_vulnerable.snap
@@ -1,0 +1,9 @@
+---
+source: tooling/sanctifier-core/tests/gallery_snapshots.rs
+expression: findings
+---
+- rule_name: arithmetic_overflow
+  severity: Warning
+  message: "Unchecked '+' operation could overflow"
+  location: "add_reward:15"
+  suggestion: Use .checked_add(rhs) or .saturating_add(rhs) to handle overflow

--- a/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__missing_ttl_fixed.snap
+++ b/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__missing_ttl_fixed.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/sanctifier-core/tests/gallery_snapshots.rs
+expression: findings
+---
+[]

--- a/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__missing_ttl_vulnerable.snap
+++ b/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__missing_ttl_vulnerable.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/sanctifier-core/tests/gallery_snapshots.rs
+expression: findings
+---
+[]

--- a/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__oracle_staleness_fixed.snap
+++ b/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__oracle_staleness_fixed.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/sanctifier-core/tests/gallery_snapshots.rs
+expression: findings
+---
+[]

--- a/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__oracle_staleness_vulnerable.snap
+++ b/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__oracle_staleness_vulnerable.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/sanctifier-core/tests/gallery_snapshots.rs
+expression: findings
+---
+[]

--- a/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__reentrancy_fixed.snap
+++ b/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__reentrancy_fixed.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/sanctifier-core/tests/gallery_snapshots.rs
+expression: findings
+---
+[]

--- a/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__reentrancy_vulnerable.snap
+++ b/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__reentrancy_vulnerable.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/sanctifier-core/tests/gallery_snapshots.rs
+expression: findings
+---
+[]

--- a/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__reinit_fixed.snap
+++ b/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__reinit_fixed.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/sanctifier-core/tests/gallery_snapshots.rs
+expression: findings
+---
+[]

--- a/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__reinit_vulnerable.snap
+++ b/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__reinit_vulnerable.snap
@@ -1,0 +1,9 @@
+---
+source: tooling/sanctifier-core/tests/gallery_snapshots.rs
+expression: findings
+---
+- rule_name: auth_gap
+  severity: Warning
+  message: "Function 'initialize' performs storage mutation without authentication"
+  location: initialize
+  suggestion: Add require_auth() or require_auth_for_args() before storage operations

--- a/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__unbounded_loop_fixed.snap
+++ b/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__unbounded_loop_fixed.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/sanctifier-core/tests/gallery_snapshots.rs
+expression: findings
+---
+[]

--- a/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__unbounded_loop_vulnerable.snap
+++ b/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__unbounded_loop_vulnerable.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/sanctifier-core/tests/gallery_snapshots.rs
+expression: findings
+---
+[]

--- a/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__upgrade_auth_fixed.snap
+++ b/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__upgrade_auth_fixed.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/sanctifier-core/tests/gallery_snapshots.rs
+expression: findings
+---
+[]

--- a/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__upgrade_auth_vulnerable.snap
+++ b/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__upgrade_auth_vulnerable.snap
@@ -1,0 +1,9 @@
+---
+source: tooling/sanctifier-core/tests/gallery_snapshots.rs
+expression: findings
+---
+- rule_name: auth_gap
+  severity: Warning
+  message: "Function 'set_upgrade_admin' performs storage mutation without authentication"
+  location: set_upgrade_admin
+  suggestion: Add require_auth() or require_auth_for_args() before storage operations

--- a/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__weak_randomness_fixed.snap
+++ b/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__weak_randomness_fixed.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/sanctifier-core/tests/gallery_snapshots.rs
+expression: findings
+---
+[]

--- a/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__weak_randomness_vulnerable.snap
+++ b/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__weak_randomness_vulnerable.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/sanctifier-core/tests/gallery_snapshots.rs
+expression: findings
+---
+[]


### PR DESCRIPTION
Closes #388

## Overview
Adds a **canonical vulnerable-contract gallery**: ten minimal Soroban contracts, each isolating *exactly one* bug class, paired with its fixed counterpart, and wires the corpus into the golden snapshot suite from #397. This gives detectors a shared, regression-proof fixture set and doubles as best-practices teaching material.

## What changed

### 20 minimal contracts (10 vulnerable + 10 fixed)
Under `tooling/sanctifier-core/tests/fixtures/gallery/`, one `*_vulnerable.rs` + `*_fixed.rs` pair per bug class. Each vulnerable file contains a single, clearly-commented flaw; each fixed file is the same contract with the minimal correct fix. They are parsed by detectors via `syn`, so they only need to be valid Rust (no compile/deploy, no new workspace crates).

### Each bug class mapped to a finding code

| # | Bug class | Finding code | Detector coverage |
|---|-----------|--------------|-------------------|
| 1 | Re-initialization | `S001` auth_gap | ✅ flagged today |
| 2 | Unchecked upgrade auth | `S010` upgrade_risk | ⚠️ surfaced via `S001` auth_gap |
| 3 | CEI / reentrancy | `S006` unsafe_pattern | 🔜 planned detector |
| 4 | Unbounded loop | `S006` unsafe_pattern | 🔜 planned detector |
| 5 | Missing TTL bump | `S006` unsafe_pattern | 🔜 planned detector |
| 6 | Weak randomness | `S006` unsafe_pattern | 🔜 planned detector |
| 7 | Integer overflow | `S003` arithmetic_overflow | ✅ flagged today |
| 8 | Allowance race (TOCTOU) | `S006` unsafe_pattern | 🔜 planned detector |
| 9 | Oracle staleness | `S006` unsafe_pattern | 🔜 planned detector |
| 10 | Confused-deputy auth | `S001` auth_gap (family) | 🔜 planned refinement |

Full mapping with file names lives in [`tests/fixtures/gallery/README.md`](https://github.com/kulayddon/sanctified/blob/feat/vulnerable-contract-gallery/tooling/sanctifier-core/tests/fixtures/gallery/README.md); finding codes are defined in `src/finding_codes.rs` / `docs/error-codes.md`.

### Wired into the snapshot test suite
`tooling/sanctifier-core/tests/gallery_snapshots.rs` runs the **full default `RuleRegistry`** over every fixture and snapshots the findings with `insta::assert_yaml_snapshot!`. The committed snapshots show:

- **re-init** and **upgrade-auth** vulnerable → `S001 auth_gap`; fixed → clean.
- **integer-overflow** vulnerable → `S003 arithmetic_overflow`; fixed → clean.
- The 7 classes with no detector yet snapshot **empty** — that empty snapshot is the regression baseline a future `[DETECTOR]` will be measured against (when it lands, the snapshot diffs and must be reviewed, proving the detector fires on the canonical fixture).

Every vulnerable fixture produces **exactly** its intended finding with zero incidental noise, and every fixed fixture is clean — confirming each contract isolates one bug class.

## Acceptance criteria
- [x] 10 vulnerable + 10 fixed minimal contracts.
- [x] Each mapped to a finding code (table above + gallery README).
- [x] Used by the snapshot test suite (`gallery_snapshots.rs`, 20 snapshots).

## Verification
- `cargo test -p sanctifier-core --test gallery_snapshots` → **20 passed**.
- `cargo fmt --all --check` and `cargo clippy -p sanctifier-core --test gallery_snapshots -- -D warnings` are clean.
- `Cargo.lock` intentionally untouched — no new dependencies are introduced (`insta` already ships with #397).

## Notes
This builds on the golden-snapshot infrastructure from #397 (already on `main`) and feeds the upcoming best-practices handbook. The "🔜 planned" rows are deliberate: the gallery is the corpus future detector work will light up, not a claim that every class is detected today.