### PR TITLE
feat(frontend): finding detail drawer with code snippet, remediation & keyboard accessibility (#372)

### DIFF
--- a/frontend/app/components/FindingDetailDrawer.tsx
+++ b/frontend/app/components/FindingDetailDrawer.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+import type { Finding, Severity } from "../types";
+import { CodeSnippet } from "./CodeSnippet";
+
+const CATEGORY_TO_CODE: Record<string, string> = {
+  "Auth Gap": "S001",
+  "Panic/Unwrap": "S002",
+  Arithmetic: "S003",
+  "Ledger Size": "S004",
+  "Unsafe Pattern": "S006",
+  "Custom Rule": "S007",
+};
+
+const DOCS_BASE =
+  "https://github.com/Centurylong/sanctifier/blob/main/docs/error-codes.md";
+
+const severityBadge: Record<Severity, string> = {
+  critical:
+    "bg-red-500/15 text-red-700 dark:text-red-400 border border-red-500/50",
+  high: "bg-orange-500/15 text-orange-700 dark:text-orange-400 border border-orange-500/50",
+  medium:
+    "bg-amber-500/15 text-amber-700 dark:text-amber-400 border border-amber-500/50",
+  low: "bg-zinc-500/15 text-zinc-700 dark:text-zinc-400 border border-zinc-500/50",
+};
+
+const FOCUSABLE =
+  'button,[href],input,select,textarea,[tabindex]:not([tabindex="-1"])';
+
+interface FindingDetailDrawerProps {
+  finding: Finding | null;
+  onClose: () => void;
+}
+
+export function FindingDetailDrawer({
+  finding,
+  onClose,
+}: FindingDetailDrawerProps) {
+  const drawerRef = useRef<HTMLDivElement>(null);
+  const savedFocusRef = useRef<Element | null>(null);
+
+  useEffect(() => {
+    if (!finding) return;
+
+    savedFocusRef.current = document.activeElement;
+
+    const drawer = drawerRef.current;
+    if (!drawer) return;
+
+    // Move focus into the drawer on open.
+    const focusables = drawer.querySelectorAll<HTMLElement>(FOCUSABLE);
+    focusables[0]?.focus();
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+
+      if (e.key === "Tab") {
+        const elements = Array.from(
+          drawer!.querySelectorAll<HTMLElement>(FOCUSABLE)
+        ).filter((el) => !el.hasAttribute("disabled"));
+
+        if (elements.length === 0) return;
+
+        const first = elements[0];
+        const last = elements[elements.length - 1];
+
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      // Restore focus to the element that triggered the drawer.
+      if (savedFocusRef.current instanceof HTMLElement) {
+        savedFocusRef.current.focus();
+      }
+    };
+  }, [finding, onClose]);
+
+  if (!finding || typeof document === "undefined") return null;
+
+  const code = CATEGORY_TO_CODE[finding.category];
+  const docsHref = code ? `${DOCS_BASE}#${code.toLowerCase()}` : DOCS_BASE;
+
+  return createPortal(
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 z-40 bg-black/40 backdrop-blur-sm"
+        aria-hidden="true"
+        onClick={onClose}
+      />
+
+      {/* Drawer panel */}
+      <div
+        ref={drawerRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Finding detail: ${finding.title}`}
+        className="fixed right-0 top-0 z-50 flex h-full w-full max-w-xl flex-col overflow-y-auto border-l border-zinc-200 bg-white shadow-2xl dark:border-zinc-800 dark:bg-zinc-950 theme-high-contrast:border-white theme-high-contrast:bg-black"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-zinc-200 px-6 py-4 dark:border-zinc-800 theme-high-contrast:border-white">
+          <h2 className="text-base font-semibold text-zinc-900 dark:text-zinc-100 theme-high-contrast:text-white">
+            Finding Detail
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="rounded-lg p-1.5 text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 16 16"
+              fill="none"
+              aria-hidden="true"
+            >
+              <path
+                d="M12 4L4 12M4 4l8 8"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex flex-1 flex-col gap-6 px-6 py-5">
+          {/* Severity + code + docs link */}
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              className={`inline-block rounded px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide ${severityBadge[finding.severity]}`}
+            >
+              {finding.severity}
+            </span>
+            <span className="rounded bg-zinc-100 px-2.5 py-0.5 font-mono text-xs font-medium text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 theme-high-contrast:bg-zinc-900 theme-high-contrast:text-white">
+              {finding.category}
+              {code && <> · {code}</>}
+            </span>
+            <a
+              href={docsHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="ml-auto text-xs text-blue-600 underline-offset-2 hover:underline dark:text-blue-400 theme-high-contrast:text-blue-300"
+            >
+              docs&nbsp;/&nbsp;explain ↗
+            </a>
+          </div>
+
+          {/* Message */}
+          <section aria-label="Message">
+            <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400 theme-high-contrast:text-zinc-300">
+              Message
+            </p>
+            <p className="text-sm text-zinc-900 dark:text-zinc-100 theme-high-contrast:text-white">
+              {finding.title}
+            </p>
+          </section>
+
+          {/* Location */}
+          <section aria-label="Location">
+            <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400 theme-high-contrast:text-zinc-300">
+              Location
+            </p>
+            <p className="font-mono text-xs text-zinc-600 dark:text-zinc-400 theme-high-contrast:text-zinc-300">
+              {finding.location}
+            </p>
+          </section>
+
+          {/* Remediation */}
+          {finding.suggestion && (
+            <section aria-label="Remediation">
+              <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400 theme-high-contrast:text-zinc-300">
+                Remediation
+              </p>
+              <p className="text-sm italic text-zinc-700 dark:text-zinc-300 theme-high-contrast:text-white">
+                {finding.suggestion}
+              </p>
+            </section>
+          )}
+
+          {/* Code snippet with highlighted offending line */}
+          {finding.snippet && (
+            <section aria-label="Code excerpt">
+              <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400 theme-high-contrast:text-zinc-300">
+                Code Excerpt
+              </p>
+              <CodeSnippet
+                code={finding.snippet}
+                highlightLine={finding.line}
+              />
+            </section>
+          )}
+        </div>
+      </div>
+    </>,
+    document.body
+  );
+}

--- a/frontend/app/components/FindingsPanel.tsx
+++ b/frontend/app/components/FindingsPanel.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import type { Finding } from "../types";
 import { filterFindings, severityCounts } from "../lib/findings-query";
 import { useFindingsQuery } from "./useFindingsQuery";
 import { SeverityFacets } from "./SeverityFacets";
 import { FindingsSearch } from "./FindingsSearch";
 import { FindingsTable } from "./FindingsTable";
+import { FindingDetailDrawer } from "./FindingDetailDrawer";
 
 interface FindingsPanelProps {
   findings: Finding[];
@@ -15,6 +16,8 @@ interface FindingsPanelProps {
 /**
  * The results experience: severity facets + debounced search + a virtualized,
  * sortable table, all driven by URL-backed state so the view is shareable.
+ * Clicking a row opens a detail drawer with code excerpt, remediation, and a
+ * link to the finding-code catalog.
  * Must be rendered inside a <Suspense> boundary because it reads useSearchParams.
  */
 export function FindingsPanel({ findings }: FindingsPanelProps) {
@@ -27,6 +30,9 @@ export function FindingsPanel({ findings }: FindingsPanelProps) {
     clearAll,
     hasActiveFilters,
   } = useFindingsQuery();
+
+  const [selectedFinding, setSelectedFinding] = useState<Finding | null>(null);
+  const closeDrawer = useCallback(() => setSelectedFinding(null), []);
 
   const counts = useMemo(
     () => severityCounts(findings, state),
@@ -79,8 +85,14 @@ export function FindingsPanel({ findings }: FindingsPanelProps) {
           sort={state.sort}
           dir={state.dir}
           onSortChange={setSort}
+          onRowClick={setSelectedFinding}
         />
       )}
+
+      <FindingDetailDrawer
+        finding={selectedFinding}
+        onClose={closeDrawer}
+      />
     </div>
   );
 }

--- a/frontend/app/components/FindingsTable.stories.tsx
+++ b/frontend/app/components/FindingsTable.stories.tsx
@@ -29,16 +29,25 @@ function makeFindings(count: number): Finding[] {
 function TableHarness({ rows }: { rows: Finding[] }) {
   const [sort, setSort] = useState<SortKey | null>("severity");
   const [dir, setDir] = useState<SortDir>("desc");
+  const [selected, setSelected] = useState<Finding | null>(null);
   return (
-    <FindingsTable
-      rows={rows}
-      sort={sort}
-      dir={dir}
-      onSortChange={(s, d) => {
-        setSort(s);
-        setDir(d);
-      }}
-    />
+    <>
+      <FindingsTable
+        rows={rows}
+        sort={sort}
+        dir={dir}
+        onSortChange={(s, d) => {
+          setSort(s);
+          setDir(d);
+        }}
+        onRowClick={setSelected}
+      />
+      {selected && (
+        <p style={{ marginTop: 8, fontSize: 12, color: "#71717a" }}>
+          Selected: {selected.id} — {selected.title}
+        </p>
+      )}
+    </>
   );
 }
 
@@ -51,7 +60,7 @@ const meta: Meta<typeof FindingsTable> = {
     docs: {
       description: {
         component:
-          "Virtualized, sortable findings table (TanStack Table + Virtual). Columns: severity, code, file:line, message. Rows with a snippet or suggestion expand inline. Sorting is controlled by the caller so it can be persisted to the URL.",
+          "Virtualized, sortable findings table (TanStack Table + Virtual). Columns: severity, code, file:line, message. Clicking a row fires onRowClick so the parent can open a detail drawer. Sorting is controlled by the caller so it can be persisted to the URL.",
       },
     },
   },

--- a/frontend/app/components/FindingsTable.tsx
+++ b/frontend/app/components/FindingsTable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import {
   createColumnHelper,
   flexRender,
@@ -13,7 +13,6 @@ import {
 } from "@tanstack/react-table";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import type { Finding, Severity } from "../types";
-import { CodeSnippet } from "./CodeSnippet";
 import { SEVERITY_RANK, type SortDir, type SortKey } from "../lib/findings-query";
 
 interface FindingsTableProps {
@@ -22,6 +21,8 @@ interface FindingsTableProps {
   sort: SortKey | null;
   dir: SortDir;
   onSortChange: (sort: SortKey | null, dir: SortDir) => void;
+  /** Called when the user clicks a row to open its detail drawer. */
+  onRowClick?: (finding: Finding) => void;
 }
 
 const severityBadge: Record<Severity, string> = {
@@ -94,10 +95,15 @@ function SortIndicator({ dir }: { dir: false | SortDir }) {
 /**
  * Virtualized findings table (handles hundreds of rows). Sorting is controlled
  * by the caller (URL-backed) via TanStack Table; rows are windowed with TanStack
- * Virtual. Rows with a snippet/suggestion expand inline to show detail, using
- * dynamic measurement so the virtualizer stays accurate.
+ * Virtual. Clicking a row fires onRowClick so the parent can open a detail drawer.
  */
-export function FindingsTable({ rows, sort, dir, onSortChange }: FindingsTableProps) {
+export function FindingsTable({
+  rows,
+  sort,
+  dir,
+  onSortChange,
+  onRowClick,
+}: FindingsTableProps) {
   // TanStack Table's useReactTable returns a mutable instance the React Compiler
   // can't memoize; opt this component out per TanStack's guidance.
   "use no memo";
@@ -130,16 +136,6 @@ export function FindingsTable({ rows, sort, dir, onSortChange }: FindingsTablePr
 
   const sortedRows = table.getRowModel().rows;
 
-  const [expanded, setExpanded] = useState<Set<string>>(new Set());
-  const toggleExpanded = useCallback((id: string) => {
-    setExpanded((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-  }, []);
-
   const scrollRef = useRef<HTMLDivElement>(null);
   const virtualizer = useVirtualizer({
     count: sortedRows.length,
@@ -147,8 +143,6 @@ export function FindingsTable({ rows, sort, dir, onSortChange }: FindingsTablePr
     estimateSize: () => 48,
     overscan: 12,
   });
-
-  const hasDetail = (f: Finding) => Boolean(f.snippet || f.suggestion);
 
   return (
     <div className="overflow-hidden rounded-lg border border-zinc-200 dark:border-zinc-800 theme-high-contrast:border-white">
@@ -197,8 +191,6 @@ export function FindingsTable({ rows, sort, dir, onSortChange }: FindingsTablePr
           {virtualizer.getVirtualItems().map((virtualItem) => {
             const row: Row<Finding> = sortedRows[virtualItem.index];
             const f = row.original;
-            const isExpanded = expanded.has(f.id);
-            const expandable = hasDetail(f);
 
             return (
               <div
@@ -210,13 +202,16 @@ export function FindingsTable({ rows, sort, dir, onSortChange }: FindingsTablePr
               >
                 <div
                   role="row"
-                  className={`${GRID} py-2.5 ${
-                    expandable
-                      ? "cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-900/60"
-                      : ""
-                  }`}
-                  onClick={expandable ? () => toggleExpanded(f.id) : undefined}
-                  aria-expanded={expandable ? isExpanded : undefined}
+                  tabIndex={0}
+                  className={`${GRID} py-2.5 cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-900/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-zinc-400`}
+                  onClick={() => onRowClick?.(f)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      onRowClick?.(f);
+                    }
+                  }}
+                  aria-label={`${f.severity} – ${f.category}: ${f.title}`}
                 >
                   {row.getVisibleCells().map((cell) => (
                     <div key={cell.id} className="min-w-0" role="cell">
@@ -224,19 +219,6 @@ export function FindingsTable({ rows, sort, dir, onSortChange }: FindingsTablePr
                     </div>
                   ))}
                 </div>
-
-                {expandable && isExpanded && (
-                  <div className="px-4 pb-4 pl-[7.75rem] text-sm">
-                    {f.suggestion && (
-                      <p className="mb-2 italic text-zinc-600 dark:text-zinc-400">
-                        💡 {f.suggestion}
-                      </p>
-                    )}
-                    {f.snippet && (
-                      <CodeSnippet code={f.snippet} highlightLine={f.line} />
-                    )}
-                  </div>
-                )}
               </div>
             );
           })}

--- a/frontend/app/terminal/page.tsx
+++ b/frontend/app/terminal/page.tsx
@@ -68,7 +68,7 @@ export default function TerminalPage() {
                     <div className="space-y-2">
                         <h1 className="text-3xl font-bold tracking-tight">Analysis Terminal</h1>
                         <p className="max-w-2xl" style={{ color: "var(--muted-foreground)" }}>
-                            Monitor your contract's security analysis in real-time. This interactive terminal
+                            Monitor your contract&apos;s security analysis in real-time. This interactive terminal
                             streams live logs directly from the Sanctifier core engine.
                         </p>
                     </div>


### PR DESCRIPTION
## Summary

Implements the finding detail drawer requested in issue #372.

- **`FindingDetailDrawer.tsx`** (new) — side panel that slides in from the right when a finding row is clicked. Displays: severity badge, category + error code (`S001`–`S007`), location, message, remediation text, and a `CodeSnippet` with the offending line highlighted. A **"docs / explain ↗"** link maps each category to its anchor in `docs/error-codes.md` on the upstream repo.
- **Keyboard accessibility** — on open, focus moves into the drawer; `Tab`/`Shift-Tab` are trapped inside the panel; `Esc` closes it and restores focus to the triggering row. Backdrop click also closes.
- **`FindingsTable.tsx`** — removes the old inline row-expansion in favour of a new `onRowClick?: (finding: Finding) => void` prop. Every row is now `tabIndex=0` with `Enter`/`Space` support and a visible focus ring (`focus-visible:ring`), making the table fully keyboard navigable.
- **`FindingsPanel.tsx`** — owns `selectedFinding` state, passes `onRowClick={setSelectedFinding}` to the table, and renders `<FindingDetailDrawer>` with a `useCallback`-stabilised `onClose` so the drawer's `useEffect` dep array stays tight.
- **`FindingsTable.stories.tsx`** — updated `TableHarness` to wire `onRowClick` and updated the component description.
- **`terminal/page.tsx`** — fix pre-existing `react/no-unescaped-entities` lint error (unescaped apostrophe).

## Acceptance criteria

- [x] Drawer shows highlighted code excerpt + remediation
- [x] Links to docs/explain for the code (`S001`–`S007` anchors in `error-codes.md`)
- [x] Accessible — focus management on open/close, focus trap, Esc to close

## Test plan

- [ ] Click any finding row → drawer opens on the right with severity, code, message, location, and (where present) remediation and code excerpt with the offending line highlighted in amber
- [ ] Press `Esc` → drawer closes, focus returns to the clicked row
- [ ] Tab through the drawer controls without focus escaping to the page behind
- [ ] Click the backdrop → drawer closes
- [ ] Click **"docs / explain ↗"** → opens the correct error-code anchor in a new tab
- [ ] Keyboard: focus a row with `Tab`, press `Enter` or `Space` → drawer opens
- [ ] `npx tsc --noEmit` passes with zero errors in `frontend/`