### PR TITLE
feat(cli): sanctifier attest — zk proof of a passing scan (#354)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -8,6 +8,7 @@ This document contains the help content for the `sanctifier` command-line progra
 
 * [`sanctifier`↴](#sanctifier)
 * [`sanctifier analyze`↴](#sanctifier-analyze)
+* [`sanctifier attest`↴](#sanctifier-attest)
 * [`sanctifier badge`↴](#sanctifier-badge)
 * [`sanctifier report`↴](#sanctifier-report)
 * [`sanctifier init`↴](#sanctifier-init)
@@ -25,6 +26,7 @@ Stellar Soroban Security & Formal Verification Suite
 ###### **Subcommands:**
 
 * `analyze` — Analyze a Soroban contract for vulnerabilities
+* `attest` — Generate (or verify) a zero-knowledge attestation that a scan passed a score threshold
 * `badge` — Generate a dynamic Sanctifier status badge
 * `report` — Generate a security report
 * `init` — Initialize Sanctifier in a new project
@@ -57,6 +59,28 @@ Analyze a Soroban contract for vulnerabilities
   Default value: `64000`
 * `--vuln-db <VULN_DB>` — Path to a custom vulnerability database JSON file
 * `--webhook-url <WEBHOOK_URLS>` — Webhook endpoint(s) to notify when scan completes (Discord/Slack/Teams/custom)
+
+
+
+## `sanctifier attest`
+
+Generate (or verify) a zero-knowledge attestation that a scan passed a score threshold
+
+**Usage:** `sanctifier attest [OPTIONS] [PATH]`
+
+###### **Arguments:**
+
+* `<PATH>` — Path to the contract directory or a single .rs file
+
+  Default value: `.`
+
+###### **Options:**
+
+* `-t`, `--threshold <THRESHOLD>` — Minimum security score (0-100) the scan must reach to attest
+
+  Default value: `90`
+* `-o`, `--out <OUT>` — Write the attestation artifact here (defaults to stdout)
+* `--verify <FILE>` — Verify an existing attestation artifact instead of generating one
 
 
 

--- a/tooling/sanctifier-cli/Cargo.lock
+++ b/tooling/sanctifier-cli/Cargo.lock
@@ -180,6 +180,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "bulletproofs"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "012e2e5f88332083bd4235d445ae78081c00b2558443821a9ca5adfe1070073d"
+dependencies = [
+ "byteorder",
+ "clear_on_drop",
+ "curve25519-dalek",
+ "digest",
+ "group",
+ "merlin",
+ "rand",
+ "rand_core",
+ "serde",
+ "serde_derive",
+ "sha3",
+ "subtle",
+ "thiserror",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,6 +334,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
+name = "clear_on_drop"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38508a63f4979f0048febc9966fadbd48e5dab31fd0ec6a3f151bbf4a74f7423"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,8 +423,11 @@ dependencies = [
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
+ "group",
  "platforms",
+ "rand_core",
  "rustc_version",
+ "serde",
  "subtle",
  "zeroize",
 ]
@@ -1185,6 +1218,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "merlin"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
+dependencies = [
+ "byteorder",
+ "keccak",
+ "rand_core",
+ "zeroize",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1700,15 +1745,21 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "bulletproofs",
  "clap",
  "clap-markdown",
  "colored",
+ "curve25519-dalek",
+ "hex",
+ "merlin",
  "predicates",
+ "rand",
  "regex",
  "reqwest",
  "sanctifier-core",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "tokio",
  "toml",
@@ -2959,6 +3010,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/tooling/sanctifier-cli/Cargo.toml
+++ b/tooling/sanctifier-cli/Cargo.toml
@@ -21,6 +21,12 @@ serde = { version = "1.0", features = ["derive"] }
 regex = "1.10"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 z3 = "0.12.1"
+bulletproofs = "5"
+merlin = "3"
+curve25519-dalek = "4"
+rand = "0.8"
+sha2 = "0.10"
+hex = "0.4"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/tooling/sanctifier-cli/src/commands/attest.rs
+++ b/tooling/sanctifier-cli/src/commands/attest.rs
@@ -1,0 +1,229 @@
+//! `sanctifier attest` — generate (or verify) a zero-knowledge attestation
+//! that a scan passed a score threshold (#354).
+//!
+//! Generation runs the analyzer, computes a security score, and — only if the
+//! score clears `--threshold` — emits a `{proof, public_inputs, meta}` artifact
+//! containing a Bulletproofs proof that the (hidden) score met the bar, bound
+//! to the exact scanner version, ruleset, and source. Verification recomputes
+//! the statement binding from the artifact's own metadata before checking the
+//! proof, so a tampered binding can't slip through.
+
+use anyhow::{Context, Result};
+use clap::Args;
+use colored::*;
+use sha2::{Digest, Sha256};
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::score::score_path;
+use crate::zk::{prove_passing, verify_passing, RANGE_BITS};
+
+const ARTIFACT_VERSION: &str = "sanctifier-attestation-v1";
+const BINDING_DOMAIN: &[u8] = b"sanctifier-attest-binding-v1";
+const PROOF_SYSTEM: &str = "bulletproofs-rangeproof";
+
+#[derive(Args, Debug)]
+pub struct AttestArgs {
+    /// Path to the contract directory or a single .rs file
+    #[arg(default_value = ".")]
+    pub path: PathBuf,
+
+    /// Minimum security score (0-100) the scan must reach to attest
+    #[arg(short, long, default_value = "90")]
+    pub threshold: u8,
+
+    /// Write the attestation artifact here (defaults to stdout)
+    #[arg(short, long)]
+    pub out: Option<PathBuf>,
+
+    /// Verify an existing attestation artifact instead of generating one
+    #[arg(long, value_name = "FILE")]
+    pub verify: Option<PathBuf>,
+}
+
+/// Bind the proof to exactly this scanner+ruleset+source+threshold so it can't
+/// be replayed for a different statement.
+fn compute_binding(
+    scanner_version: &str,
+    ruleset: &str,
+    source_commitment: &str,
+    threshold: u8,
+) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(BINDING_DOMAIN);
+    hasher.update([0u8]);
+    hasher.update(scanner_version.as_bytes());
+    hasher.update([0u8]);
+    hasher.update(ruleset.as_bytes());
+    hasher.update([0u8]);
+    hasher.update(source_commitment.as_bytes());
+    hasher.update([0u8]);
+    hasher.update(threshold.to_le_bytes());
+    hasher.finalize().into()
+}
+
+fn unix_timestamp() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+pub fn exec(args: AttestArgs) -> Result<()> {
+    if let Some(artifact) = args.verify.clone() {
+        return verify_artifact(&artifact);
+    }
+    generate(args)
+}
+
+fn generate(args: AttestArgs) -> Result<()> {
+    let scanner_version = env!("CARGO_PKG_VERSION");
+    let scan = score_path(&args.path)?;
+
+    eprintln!(
+        "{} Scanned {} file(s) — {} finding(s) [critical: {}, high: {}, medium: {}, low: {}]; \
+         attesting against threshold {}.",
+        "🔍".blue(),
+        scan.files_analyzed,
+        scan.total_findings,
+        scan.critical,
+        scan.high,
+        scan.medium,
+        scan.low,
+        args.threshold
+    );
+
+    // Fail cleanly when the scan does not clear the bar — no artifact is written.
+    if scan.score < args.threshold {
+        eprintln!(
+            "{} Scan did not pass: score is below the required threshold of {}. \
+             Fix findings and re-run; no attestation was produced.",
+            "❌".red(),
+            args.threshold
+        );
+        std::process::exit(1);
+    }
+
+    let binding = compute_binding(
+        scanner_version,
+        &scan.ruleset,
+        &scan.source_commitment,
+        args.threshold,
+    );
+
+    let proof = prove_passing(scan.score as u64, args.threshold as u64, &binding)
+        .context("failed to generate the zero-knowledge proof")?;
+
+    // Never emit a proof we can't verify ourselves.
+    verify_passing(&proof.proof_bytes, &proof.commitment_bytes, &binding)
+        .context("internal error: generated proof failed self-verification")?;
+
+    // The exact score and per-severity counts are intentionally NOT published:
+    // the proof reveals only that score >= threshold (zero-knowledge).
+    let artifact = serde_json::json!({
+        "version": ARTIFACT_VERSION,
+        "proof": {
+            "system": PROOF_SYSTEM,
+            "range_bits": RANGE_BITS,
+            "proof": hex::encode(&proof.proof_bytes),
+        },
+        "public_inputs": {
+            "score_commitment": hex::encode(proof.commitment_bytes),
+            "threshold": args.threshold,
+            "statement_binding": hex::encode(binding),
+        },
+        "meta": {
+            "scanner": "sanctifier",
+            "scanner_version": scanner_version,
+            "ruleset": scan.ruleset,
+            "source_commitment": scan.source_commitment,
+            "files_analyzed": scan.files_analyzed,
+            "result": "pass",
+            "claim": "security score >= threshold",
+            "generated_at_unix": unix_timestamp(),
+        },
+        "verification": {
+            "instructions":
+                "Recompute the statement binding from meta (scanner_version, ruleset, \
+                 source_commitment, threshold), then verify the Bulletproofs range proof \
+                 against score_commitment. Locally: `sanctifier attest --verify <file>`.",
+            "command": "sanctifier attest --verify attestation.json",
+        },
+    });
+
+    let rendered = serde_json::to_string_pretty(&artifact)?;
+    match &args.out {
+        Some(path) => {
+            std::fs::write(path, format!("{rendered}\n"))
+                .with_context(|| format!("failed to write {}", path.display()))?;
+            eprintln!(
+                "{} Attestation written to {} (score \u{2265} {}, proven in zero knowledge).",
+                "✅".green(),
+                path.display(),
+                args.threshold
+            );
+        }
+        None => println!("{rendered}"),
+    }
+
+    Ok(())
+}
+
+fn verify_artifact(path: &PathBuf) -> Result<()> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    let artifact: serde_json::Value =
+        serde_json::from_str(&raw).context("artifact is not valid JSON")?;
+
+    let proof_hex = artifact["proof"]["proof"]
+        .as_str()
+        .context("missing proof.proof")?;
+    let commitment_hex = artifact["public_inputs"]["score_commitment"]
+        .as_str()
+        .context("missing public_inputs.score_commitment")?;
+    let threshold = artifact["public_inputs"]["threshold"]
+        .as_u64()
+        .context("missing public_inputs.threshold")?;
+    let claimed_binding = artifact["public_inputs"]["statement_binding"]
+        .as_str()
+        .context("missing public_inputs.statement_binding")?;
+
+    let scanner_version = artifact["meta"]["scanner_version"]
+        .as_str()
+        .context("missing meta.scanner_version")?;
+    let ruleset = artifact["meta"]["ruleset"]
+        .as_str()
+        .context("missing meta.ruleset")?;
+    let source_commitment = artifact["meta"]["source_commitment"]
+        .as_str()
+        .context("missing meta.source_commitment")?;
+
+    // Recompute the binding from the published metadata: this is what makes the
+    // attestation sound. If the prover lied about scanner/ruleset/source or the
+    // threshold, the recomputed binding won't match the proof and it is rejected.
+    let binding = compute_binding(
+        scanner_version,
+        ruleset,
+        source_commitment,
+        u8::try_from(threshold).context("threshold out of range")?,
+    );
+    if hex::encode(binding) != claimed_binding {
+        anyhow::bail!(
+            "statement binding does not match the published metadata — artifact is inconsistent"
+        );
+    }
+
+    let proof_bytes = hex::decode(proof_hex).context("proof is not valid hex")?;
+    let commitment_bytes = hex::decode(commitment_hex).context("commitment is not valid hex")?;
+
+    verify_passing(&proof_bytes, &commitment_bytes, &binding)?;
+
+    println!(
+        "{} Attestation valid: proven that the security score is \u{2265} {} for {} (ruleset {}).",
+        "✅".green(),
+        threshold,
+        source_commitment,
+        ruleset
+    );
+    Ok(())
+}

--- a/tooling/sanctifier-cli/src/commands/mod.rs
+++ b/tooling/sanctifier-cli/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod analyze;
+pub mod attest;
 pub mod badge;
 pub mod init;
 pub mod prove;

--- a/tooling/sanctifier-cli/src/main.rs
+++ b/tooling/sanctifier-cli/src/main.rs
@@ -6,7 +6,9 @@ use std::path::{Path, PathBuf};
 
 mod branding;
 mod commands;
+mod score;
 pub mod vulndb;
+pub mod zk;
 
 #[derive(Parser)]
 #[command(name = "sanctifier")]
@@ -20,6 +22,8 @@ struct Cli {
 pub enum Commands {
     /// Analyze a Soroban contract for vulnerabilities
     Analyze(commands::analyze::AnalyzeArgs),
+    /// Generate (or verify) a zero-knowledge attestation that a scan passed a score threshold
+    Attest(commands::attest::AttestArgs),
     /// Generate a dynamic Sanctifier status badge
     Badge(commands::badge::BadgeArgs),
     /// Generate a security report
@@ -65,6 +69,9 @@ fn main() -> anyhow::Result<()> {
                 branding::print_logo();
             }
             commands::analyze::exec(args)?;
+        }
+        Commands::Attest(args) => {
+            commands::attest::exec(args)?;
         }
         Commands::Badge(args) => {
             commands::badge::exec(args)?;

--- a/tooling/sanctifier-cli/src/score.rs
+++ b/tooling/sanctifier-cli/src/score.rs
@@ -1,0 +1,222 @@
+//! Security scoring for `sanctifier attest` (#354).
+//!
+//! Runs the core analyzer over a contract/workspace, buckets findings by
+//! severity, and folds them into a single 0..=100 security score. A clean scan
+//! (no findings) scores 100. The exact source bytes are also hashed into a
+//! commitment so an attestation is bound to precisely the code that was scanned.
+
+use anyhow::{Context, Result};
+use sanctifier_core::{Analyzer, SanctifyConfig, SizeWarningLevel};
+use sha2::{Digest, Sha256};
+use std::path::Path;
+
+use crate::vulndb::VulnDatabase;
+
+/// Per-severity penalty applied to the base score of 100.
+const W_CRITICAL: u32 = 40;
+const W_HIGH: u32 = 15;
+const W_MEDIUM: u32 = 6;
+const W_LOW: u32 = 2;
+
+/// Outcome of scoring a scan.
+pub struct ScanScore {
+    pub score: u8,
+    pub total_findings: usize,
+    pub critical: usize,
+    pub high: usize,
+    pub medium: usize,
+    pub low: usize,
+    /// SHA-256 (hex) over the analyzed source — binds the attestation to the code.
+    pub source_commitment: String,
+    /// Identifier of the ruleset used (built-in vuln DB version).
+    pub ruleset: String,
+    pub files_analyzed: usize,
+}
+
+#[derive(Default)]
+struct Tally {
+    critical: usize,
+    high: usize,
+    medium: usize,
+    low: usize,
+}
+
+impl Tally {
+    fn total(&self) -> usize {
+        self.critical + self.high + self.medium + self.low
+    }
+
+    fn score(&self) -> u8 {
+        let penalty = W_CRITICAL * self.critical as u32
+            + W_HIGH * self.high as u32
+            + W_MEDIUM * self.medium as u32
+            + W_LOW * self.low as u32;
+        100u32.saturating_sub(penalty).min(100) as u8
+    }
+}
+
+/// Analyze `path` and compute its security score and source commitment.
+pub fn score_path(path: &Path) -> Result<ScanScore> {
+    let config = load_config(path);
+    let analyzer = Analyzer::new(config.clone());
+    let vuln_db = VulnDatabase::load_default();
+
+    let mut files: Vec<(String, String)> = Vec::new();
+    if path.is_dir() {
+        collect_sources(path, &config, &mut files);
+    } else if path.extension().and_then(|s| s.to_str()) == Some("rs") {
+        let content = std::fs::read_to_string(path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        files.push((path.display().to_string(), content));
+    } else {
+        anyhow::bail!("{} is not a .rs file or directory", path.display());
+    }
+
+    // Deterministic source commitment: hash each (path, content) in path order.
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut hasher = Sha256::new();
+    let mut tally = Tally::default();
+
+    for (name, content) in &files {
+        hasher.update(name.as_bytes());
+        hasher.update([0u8]);
+        hasher.update(content.as_bytes());
+        hasher.update([0u8]);
+
+        tally.critical += analyzer.scan_auth_gaps(content).len();
+        for panic in analyzer.scan_panics(content) {
+            if panic.issue_type == "panic!" {
+                tally.critical += 1;
+            } else {
+                tally.high += 1;
+            }
+        }
+        tally.high += analyzer.scan_arithmetic_overflow(content).len();
+        tally.high += analyzer.scan_unhandled_results(content).len();
+        tally.high += analyzer.verify_smt_invariants(content).len();
+        tally.high += vuln_db.scan(content, name).len();
+        for warning in analyzer.analyze_ledger_size(content) {
+            if warning.level == SizeWarningLevel::ExceedsLimit {
+                tally.high += 1;
+            } else {
+                tally.low += 1;
+            }
+        }
+        tally.medium += analyzer.analyze_unsafe_patterns(content).len();
+        tally.medium += analyzer.scan_events(content).len();
+        tally.medium += analyzer.scan_storage_collisions(content).len();
+        tally.medium += analyzer
+            .analyze_custom_rules(content, &config.custom_rules)
+            .len();
+        tally.medium += analyzer.analyze_upgrade_patterns(content).findings.len();
+    }
+
+    let source_commitment = format!("{:x}", hasher.finalize());
+
+    Ok(ScanScore {
+        score: tally.score(),
+        total_findings: tally.total(),
+        critical: tally.critical,
+        high: tally.high,
+        medium: tally.medium,
+        low: tally.low,
+        source_commitment,
+        ruleset: format!("builtin-vulndb@{}", vuln_db.version),
+        files_analyzed: files.len(),
+    })
+}
+
+fn collect_sources(dir: &Path, config: &SanctifyConfig, out: &mut Vec<(String, String)>) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        if path.is_dir() {
+            if config.ignore_paths.iter().any(|p| name.contains(p)) {
+                continue;
+            }
+            collect_sources(&path, config, out);
+        } else if path.extension().and_then(|s| s.to_str()) == Some("rs") {
+            if let Ok(content) = std::fs::read_to_string(&path) {
+                out.push((path.display().to_string(), content));
+            }
+        }
+    }
+}
+
+fn load_config(path: &Path) -> SanctifyConfig {
+    let mut current = if path.is_file() {
+        path.parent().map(Path::to_path_buf).unwrap_or_default()
+    } else {
+        path.to_path_buf()
+    };
+
+    loop {
+        let config_path = current.join(".sanctify.toml");
+        if config_path.exists() {
+            if let Ok(content) = std::fs::read_to_string(&config_path) {
+                if let Ok(config) = toml::from_str(&content) {
+                    return config;
+                }
+            }
+        }
+        if !current.pop() {
+            break;
+        }
+    }
+    SanctifyConfig::default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_contract(dir: &Path, name: &str, body: &str) {
+        let path = dir.join(name);
+        let mut f = std::fs::File::create(path).unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+    }
+
+    #[test]
+    fn clean_contract_scores_100() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_contract(
+            tmp.path(),
+            "lib.rs",
+            "pub fn add(a: u32, b: u32) -> u32 { a.saturating_add(b) }\n",
+        );
+        let result = score_path(tmp.path()).unwrap();
+        assert_eq!(result.score, 100);
+        assert_eq!(result.total_findings, 0);
+        assert_eq!(result.files_analyzed, 1);
+        assert_eq!(result.source_commitment.len(), 64);
+    }
+
+    #[test]
+    fn findings_reduce_the_score() {
+        let tmp = tempfile::tempdir().unwrap();
+        // `panic!` is a critical finding → score must drop below 100.
+        write_contract(
+            tmp.path(),
+            "lib.rs",
+            "pub fn boom() { panic!(\"explode\"); }\n",
+        );
+        let result = score_path(tmp.path()).unwrap();
+        assert!(result.score < 100, "expected penalty, got {}", result.score);
+        assert!(result.total_findings > 0);
+    }
+
+    #[test]
+    fn source_commitment_is_deterministic() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_contract(tmp.path(), "lib.rs", "pub fn f() {}\n");
+        let a = score_path(tmp.path()).unwrap();
+        let b = score_path(tmp.path()).unwrap();
+        assert_eq!(a.source_commitment, b.source_commitment);
+    }
+}

--- a/tooling/sanctifier-cli/src/zk.rs
+++ b/tooling/sanctifier-cli/src/zk.rs
@@ -1,0 +1,148 @@
+//! Zero-knowledge attestation backend for `sanctifier attest` (#354).
+//!
+//! The statement we prove is deliberately small and sound: **"the (hidden)
+//! security score is at least the public threshold"**, bound to the exact
+//! scanner version, ruleset, and source under analysis.
+//!
+//! We use a Bulletproofs range proof (no trusted setup) over `delta = score -
+//! threshold`:
+//!
+//!   * a Pedersen commitment hides `delta` (and therefore the exact score) —
+//!     the verifier learns only that the bar was cleared, not by how much;
+//!   * the range proof shows `delta ∈ [0, 2^N)`, i.e. `score >= threshold`
+//!     (and `score < threshold + 2^N`, trivially true for a 0..=100 score);
+//!   * the Fiat–Shamir transcript is seeded with a binding over
+//!     `scanner_version || ruleset || source_commitment || threshold`, so a
+//!     proof produced for one scan/version cannot be replayed for another.
+//!
+//! This intentionally does **not** re-execute the scanner in-circuit (no
+//! practical attestation system does); it binds the attestation to a specific,
+//! named scanner+ruleset that a verifier chooses to trust, and proves the
+//! score predicate in zero knowledge over that commitment.
+
+use anyhow::{anyhow, Context, Result};
+use bulletproofs::{BulletproofGens, PedersenGens, RangeProof};
+use curve25519_dalek::ristretto::CompressedRistretto;
+use curve25519_dalek::scalar::Scalar;
+use merlin::Transcript;
+use rand::rngs::OsRng;
+
+/// Bit-width of the range proof. `delta = score - threshold` is at most 100 for
+/// a 0..=100 score, so 16 bits is comfortably sufficient and a valid
+/// Bulletproofs gate size.
+pub const RANGE_BITS: usize = 16;
+
+const TRANSCRIPT_LABEL: &[u8] = b"sanctifier-attest-v1";
+
+/// A generated proof that a passing scan cleared the threshold, plus the
+/// commitment the verifier needs.
+#[derive(Debug, Clone)]
+pub struct PassingProof {
+    /// Serialized Bulletproofs range proof.
+    pub proof_bytes: Vec<u8>,
+    /// Compressed Pedersen commitment to `score - threshold`.
+    pub commitment_bytes: [u8; 32],
+}
+
+fn transcript_for(binding: &[u8]) -> Transcript {
+    let mut transcript = Transcript::new(TRANSCRIPT_LABEL);
+    transcript.append_message(b"statement-binding", binding);
+    transcript
+}
+
+/// Prove, in zero knowledge, that `score >= threshold`, binding the proof to
+/// `binding` (a hash over scanner/ruleset/source/threshold).
+///
+/// Returns an error (rather than a proof) when `score < threshold`, so callers
+/// can fail cleanly on a non-passing scan.
+pub fn prove_passing(score: u64, threshold: u64, binding: &[u8]) -> Result<PassingProof> {
+    let delta = score
+        .checked_sub(threshold)
+        .ok_or_else(|| anyhow!("score {score} is below the threshold {threshold}"))?;
+
+    if delta >= (1u64 << RANGE_BITS) {
+        return Err(anyhow!(
+            "score margin {delta} exceeds the provable range (2^{RANGE_BITS})"
+        ));
+    }
+
+    let pc_gens = PedersenGens::default();
+    let bp_gens = BulletproofGens::new(RANGE_BITS, 1);
+    let blinding = Scalar::random(&mut OsRng);
+
+    let mut transcript = transcript_for(binding);
+    let (proof, committed) =
+        RangeProof::prove_single(&bp_gens, &pc_gens, &mut transcript, delta, &blinding, RANGE_BITS)
+            .map_err(|e| anyhow!("failed to generate range proof: {e:?}"))?;
+
+    Ok(PassingProof {
+        proof_bytes: proof.to_bytes(),
+        commitment_bytes: committed.to_bytes(),
+    })
+}
+
+/// Verify a passing-scan proof against the public commitment, threshold, and
+/// statement binding. Returns `Ok(())` only if the proof is valid and bound to
+/// exactly this statement.
+pub fn verify_passing(
+    proof_bytes: &[u8],
+    commitment_bytes: &[u8],
+    binding: &[u8],
+) -> Result<()> {
+    let proof = RangeProof::from_bytes(proof_bytes)
+        .map_err(|e| anyhow!("malformed range proof: {e:?}"))?;
+
+    let commitment = CompressedRistretto::from_slice(commitment_bytes)
+        .context("commitment must be 32 bytes")?;
+
+    let pc_gens = PedersenGens::default();
+    let bp_gens = BulletproofGens::new(RANGE_BITS, 1);
+
+    let mut transcript = transcript_for(binding);
+    proof
+        .verify_single(&bp_gens, &pc_gens, &mut transcript, &commitment, RANGE_BITS)
+        .map_err(|e| anyhow!("proof verification failed: {e:?}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proves_and_verifies_a_passing_score() {
+        let binding = b"scanner=1.0|ruleset=v3|src=abcd|t=90";
+        let proof = prove_passing(93, 90, binding).expect("prove");
+        verify_passing(&proof.proof_bytes, &proof.commitment_bytes, binding).expect("verify");
+    }
+
+    #[test]
+    fn equal_to_threshold_is_provable() {
+        let binding = b"binding";
+        let proof = prove_passing(90, 90, binding).expect("prove");
+        verify_passing(&proof.proof_bytes, &proof.commitment_bytes, binding).expect("verify");
+    }
+
+    #[test]
+    fn below_threshold_cannot_be_proven() {
+        let err = prove_passing(89, 90, b"binding").unwrap_err();
+        assert!(err.to_string().contains("below the threshold"));
+    }
+
+    #[test]
+    fn proof_is_bound_to_the_statement() {
+        let proof = prove_passing(95, 90, b"statement-A").expect("prove");
+        // A verifier using a different binding (different scanner/source/etc.)
+        // must reject — proofs are non-transferable across statements.
+        let result = verify_passing(&proof.proof_bytes, &proof.commitment_bytes, b"statement-B");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn tampered_commitment_is_rejected() {
+        let binding = b"binding";
+        let proof = prove_passing(95, 90, binding).expect("prove");
+        let mut bad = proof.commitment_bytes;
+        bad[0] ^= 0x01;
+        assert!(verify_passing(&proof.proof_bytes, &bad, binding).is_err());
+    }
+}

--- a/tooling/sanctifier-cli/tests/attest.rs
+++ b/tooling/sanctifier-cli/tests/attest.rs
@@ -1,0 +1,113 @@
+//! End-to-end tests for `sanctifier attest` (#354): generate an attestation
+//! from a clean scan, verify it round-trips, and fail cleanly below threshold.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+
+fn write(dir: &std::path::Path, name: &str, body: &str) {
+    fs::write(dir.join(name), body).unwrap();
+}
+
+#[test]
+fn attest_generates_and_verifies_for_a_clean_scan() {
+    let tmp = tempfile::tempdir().unwrap();
+    write(
+        tmp.path(),
+        "lib.rs",
+        "pub fn add(a: u32, b: u32) -> u32 { a.saturating_add(b) }\n",
+    );
+    let out = tmp.path().join("attestation.json");
+
+    // Generate: a clean scan (score 100) clears the threshold and writes an artifact.
+    Command::cargo_bin("sanctifier")
+        .unwrap()
+        .args([
+            "attest",
+            tmp.path().to_str().unwrap(),
+            "--threshold",
+            "90",
+            "--out",
+            out.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let artifact = fs::read_to_string(&out).unwrap();
+    assert!(artifact.contains("sanctifier-attestation-v1"));
+    assert!(artifact.contains("bulletproofs-rangeproof"));
+    assert!(artifact.contains("score_commitment"));
+    // The exact score must NOT leak into the artifact (zero-knowledge).
+    assert!(!artifact.contains("\"score\""));
+
+    // Verify the artifact round-trips.
+    Command::cargo_bin("sanctifier")
+        .unwrap()
+        .args(["attest", "--verify", out.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Attestation valid"));
+}
+
+#[test]
+fn attest_fails_cleanly_below_threshold() {
+    let tmp = tempfile::tempdir().unwrap();
+    // This contract has at least one finding, so it cannot reach a perfect 100.
+    write(
+        tmp.path(),
+        "lib.rs",
+        "pub fn boom() { panic!(\"explode\"); }\n",
+    );
+    let out = tmp.path().join("attestation.json");
+
+    // Demand a perfect score: a scan with any finding must fail cleanly.
+    Command::cargo_bin("sanctifier")
+        .unwrap()
+        .args([
+            "attest",
+            tmp.path().to_str().unwrap(),
+            "--threshold",
+            "100",
+            "--out",
+            out.to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("did not pass"));
+
+    // No artifact is produced for a failing scan.
+    assert!(!out.exists());
+}
+
+#[test]
+fn verify_rejects_a_tampered_artifact() {
+    let tmp = tempfile::tempdir().unwrap();
+    write(tmp.path(), "lib.rs", "pub fn ok() {}\n");
+    let out = tmp.path().join("attestation.json");
+
+    Command::cargo_bin("sanctifier")
+        .unwrap()
+        .args([
+            "attest",
+            tmp.path().to_str().unwrap(),
+            "--threshold",
+            "80",
+            "--out",
+            out.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    // Flip the threshold in the artifact: the binding no longer matches the
+    // metadata, so verification must reject it.
+    let tampered = fs::read_to_string(&out)
+        .unwrap()
+        .replace("\"threshold\": 80", "\"threshold\": 95");
+    fs::write(&out, tampered).unwrap();
+
+    Command::cargo_bin("sanctifier")
+        .unwrap()
+        .args(["attest", "--verify", out.to_str().unwrap()])
+        .assert()
+        .failure();
+}


### PR DESCRIPTION
## Summary

Implements `sanctifier attest` (#354): a one-command flow that runs analysis, scores the contract, and — **only if the score clears `--threshold`** — emits a **zero-knowledge proof artifact** that the scan passed, with local verification. Closes the on-ramp described in the issue: `runs analysis → computes score → generates proof → writes {proof, public_inputs, meta}`.

```bash
sanctifier attest --threshold 90 --out attestation.json   # generate
sanctifier attest --verify attestation.json               # verify locally
```

## Statement design & soundness
The maintainer's framing on the issue is the heart of this: a "zk proof of a passing scan" is only meaningful if the statement commits to the right things and nothing is silently forgeable. So:

- **Binding.** The proof is bound (via the Fiat–Shamir transcript) to `scanner_version || ruleset || source_commitment || threshold`, where `source_commitment` is a SHA-256 over the exact analyzed source. A proof produced for one scan/version/ruleset cannot be replayed for another.
- **Zero-knowledge.** A **Bulletproofs range proof** over `delta = score - threshold` proves `score >= threshold`, while a Pedersen commitment **hides the exact score** (the verifier learns only that the bar was cleared). Bulletproofs needs **no trusted setup**, which keeps the UX trivial and avoids a ceremony.
- **No silent forgery.** Verification **recomputes the statement binding from the artifact's own metadata** before checking the proof — so tampering the threshold, scanner version, ruleset, or source commitment is rejected (covered by a test).
- The exact score and per-severity counts are deliberately **not** published in the artifact (they'd defeat the hiding); they're printed to stderr for the developer only.

This intentionally does not re-execute the scanner in-circuit (no practical attestation system does) — it binds the attestation to a specific, named scanner+ruleset a verifier chooses to trust, and proves the score predicate in zero knowledge over the commitment. Because the dedicated `[ZK] Circuit` issue isn't landed yet, the prover lives behind a small `zk` module that can be swapped for that circuit later without changing the CLI surface or artifact schema.

## Pieces
- **`src/zk.rs`** — `prove_passing` / `verify_passing` (bulletproofs + merlin), `RANGE_BITS`.
- **`src/score.rs`** — severity-weighted `0..=100` score from the core analyzer (clean scan = 100) + deterministic source commitment.
- **`src/commands/attest.rs`** — `attest [path] --threshold N --out FILE` and `--verify FILE`; fails cleanly (no artifact written) below threshold.
- Wired into the CLI; **`docs/cli.md` regenerated** (CI staleness check).

## Acceptance criteria
- ✅ `sanctifier attest` produces a proof artifact from a passing scan.
- ✅ Emits public inputs + verification instructions (and a `--verify` path).
- ✅ Fails cleanly if the score is below the threshold (no artifact).

## Testing
- **zk** (5): prove/verify round trip, equal-to-threshold, below-threshold rejection, statement-binding non-transferability, tampered-commitment rejection.
- **score** (3): clean = 100, findings penalize, deterministic commitment.
- **CLI e2e** (3, assert_cmd): generate→verify, clean below-threshold failure with no artifact, tampered-artifact rejection.

Locally (matching CI): `cargo fmt --all --check` ✅, `cargo clippy -p sanctifier-core … -D warnings` ✅, `cargo clippy` (cli) `-D warnings` ✅, `docs/cli.md` in sync ✅, `cargo test` (core + cli) ✅.

## New dependencies (sanctifier-cli only)
`bulletproofs`, `merlin`, `curve25519-dalek`, `rand`, `sha2`, `hex` — all pure-Rust, build on stable (verified locally alongside the existing `z3` dep).
