### PR TITLE
feat(frontend): scan page — paste source or upload .rs/.zip (#374)

### DIFF
--- a/frontend/app/api/analyze/route.ts
+++ b/frontend/app/api/analyze/route.ts
@@ -1,60 +1,274 @@
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { spawn } from "child_process";
-import path from "path";
+import type { AnalysisReport, UnsafePattern, ArithmeticIssue, PanicIssue } from "../../types";
 
+// ---------------------------------------------------------------------------
+// GET – streaming terminal endpoint (existing behaviour)
+// ---------------------------------------------------------------------------
 export async function GET(request: NextRequest) {
-    const searchParams = request.nextUrl.searchParams;
-    const projectPath = searchParams.get("path") || ".";
+  const searchParams = request.nextUrl.searchParams;
+  const projectPath = searchParams.get("path") || ".";
 
-    // In a real environment, we'd want to validate the path to prevent security issues.
-    // For this exercise, we'll assume the path is safe or controlled.
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    start(controller) {
+      const cliProcess = spawn(
+        "cargo",
+        ["run", "--bin", "sanctifier", "--", "analyze", "--path", projectPath],
+        {
+          cwd: "/home/rampop/Sanctifier",
+          env: { ...process.env, FORCE_COLOR: "0" },
+        }
+      );
 
-    const encoder = new TextEncoder();
-    const stream = new ReadableStream({
-        start(controller) {
-            // Find the sanctifier binary. Assuming it's in the workspace root or path.
-            // For development, we might need to run 'cargo run --bin sanctifier' 
-            // but let's assume 'sanctifier' is in the PATH or we can find it.
+      const sendLog = (data: string) => {
+        const lines = data.split("\n");
+        for (const line of lines) {
+          if (line.trim()) {
+            controller.enqueue(
+              encoder.encode(`data: ${JSON.stringify(line)}\n\n`)
+            );
+          }
+        }
+      };
 
-            const cliProcess = spawn("cargo", ["run", "--bin", "sanctifier", "--", "analyze", "--path", projectPath], {
-                cwd: "/home/rampop/Sanctifier", // Run from project root
-                env: { ...process.env, FORCE_COLOR: "0" }, // Disable colors for simpler parsing initially
-            });
+      cliProcess.stdout.on("data", (data) => sendLog(data.toString()));
+      cliProcess.stderr.on("data", (data) =>
+        sendLog(`[DEBUG] ${data.toString()}`)
+      );
+      cliProcess.on("close", (code) => {
+        controller.enqueue(
+          encoder.encode(
+            `data: ${JSON.stringify(`--- Analysis complete with exit code ${code} ---`)}\n\n`
+          )
+        );
+        controller.close();
+      });
+      cliProcess.on("error", (err) => {
+        controller.enqueue(
+          encoder.encode(
+            `data: ${JSON.stringify(`Error spawning process: ${err.message}`)}\n\n`
+          )
+        );
+        controller.close();
+      });
+    },
+  });
 
-            const sendLog = (data: string) => {
-                const lines = data.split("\n");
-                for (const line of lines) {
-                    if (line.trim()) {
-                        controller.enqueue(encoder.encode(`data: ${JSON.stringify(line)}\n\n`));
-                    }
-                }
-            };
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}
 
-            cliProcess.stdout.on("data", (data) => {
-                sendLog(data.toString());
-            });
+// ---------------------------------------------------------------------------
+// POST – scan submitted source code and return an AnalysisReport
+// ---------------------------------------------------------------------------
 
-            cliProcess.stderr.on("data", (data) => {
-                sendLog(`[DEBUG] ${data.toString()}`);
-            });
+const MAX_SOURCE_BYTES = 512 * 1024; // 512 KB
+const ALLOWED_EXTENSIONS = [".rs", ".zip"];
 
-            cliProcess.on("close", (code) => {
-                controller.enqueue(encoder.encode(`data: ${JSON.stringify(`--- Analysis complete with exit code ${code} ---`)}\n\n`));
-                controller.close();
-            });
+export async function POST(request: NextRequest) {
+  try {
+    let source = "";
+    let filename = "contract.rs";
 
-            cliProcess.on("error", (err) => {
-                controller.enqueue(encoder.encode(`data: ${JSON.stringify(`Error spawning process: ${err.message}`)}\n\n`));
-                controller.close();
-            });
-        },
-    });
+    const ct = request.headers.get("content-type") ?? "";
 
-    return new Response(stream, {
-        headers: {
-            "Content-Type": "text/event-stream",
-            "Cache-Control": "no-cache",
-            Connection: "keep-alive",
-        },
-    });
+    if (ct.includes("multipart/form-data")) {
+      const form = await request.formData();
+
+      const fileField = form.get("file");
+      if (fileField instanceof File) {
+        const ext = "." + fileField.name.split(".").pop()?.toLowerCase();
+        if (!ALLOWED_EXTENSIONS.includes(ext)) {
+          return NextResponse.json(
+            { error: `Only ${ALLOWED_EXTENSIONS.join(", ")} files are allowed.` },
+            { status: 400 }
+          );
+        }
+        if (fileField.size > MAX_SOURCE_BYTES) {
+          return NextResponse.json(
+            { error: "File too large — maximum size is 512 KB." },
+            { status: 400 }
+          );
+        }
+        filename = fileField.name;
+        if (ext === ".zip") {
+          return NextResponse.json(
+            {
+              error:
+                "Zip scanning via the web UI is not yet supported. " +
+                "Extract the archive and paste the .rs source, or run: sanctifier analyze --path ./your-contract",
+            },
+            { status: 422 }
+          );
+        }
+        source = await fileField.text();
+      } else {
+        const sourceField = form.get("source");
+        if (typeof sourceField !== "string" || !sourceField.trim()) {
+          return NextResponse.json(
+            { error: "No source code provided." },
+            { status: 400 }
+          );
+        }
+        source = sourceField;
+      }
+    } else {
+      // application/json
+      const body = (await request.json()) as { source?: string };
+      if (!body.source?.trim()) {
+        return NextResponse.json(
+          { error: "No source code provided." },
+          { status: 400 }
+        );
+      }
+      source = body.source;
+    }
+
+    if (new TextEncoder().encode(source).length > MAX_SOURCE_BYTES) {
+      return NextResponse.json(
+        { error: "Source too large — maximum size is 512 KB." },
+        { status: 400 }
+      );
+    }
+
+    const report = analyzeRustSource(source);
+    return NextResponse.json(report);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json(
+      { error: `Analysis failed: ${message}` },
+      { status: 500 }
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Lightweight static analysis (mirrors sanctifier-core heuristics in JS)
+// ---------------------------------------------------------------------------
+
+function analyzeRustSource(source: string): AnalysisReport {
+  const lines = source.split("\n");
+
+  const unsafePatterns: UnsafePattern[] = [];
+  const panicIssues: PanicIssue[] = [];
+  const arithmeticIssues: ArithmeticIssue[] = [];
+  const authGaps: string[] = [];
+
+  // ── Pass 1: line-by-line patterns ─────────────────────────────────────────
+  for (let i = 0; i < lines.length; i++) {
+    const lineNo = i + 1;
+    const line = lines[i];
+    const trimmed = line.trim();
+
+    // panic! / unwrap / expect
+    if (/\bpanic!\s*\(/.test(line)) {
+      panicIssues.push({
+        function_name: nearestFunctionName(lines, i),
+        issue_type: "panic!",
+        location: `line ${lineNo}`,
+      });
+    }
+    if (/\.unwrap\s*\(\)/.test(line)) {
+      unsafePatterns.push({
+        pattern_type: "Unwrap",
+        line: lineNo,
+        snippet: trimmed.slice(0, 120),
+      });
+    }
+    if (/\.expect\s*\(/.test(line)) {
+      unsafePatterns.push({
+        pattern_type: "Expect",
+        line: lineNo,
+        snippet: trimmed.slice(0, 120),
+      });
+    }
+
+    // Unchecked arithmetic: integer literal arithmetic without checked_* variants
+    if (
+      /\bi(8|16|32|64|128|size)\b/.test(line) &&
+      /[+\-*]/.test(line) &&
+      !/\.checked_(add|sub|mul|div|rem)/.test(line) &&
+      !/\/\//.test(trimmed.slice(0, trimmed.search(/[+\-*]/)))
+    ) {
+      const op = (line.match(/[+\-*]/) ?? [])[0] ?? "+";
+      const opName = op === "+" ? "addition" : op === "-" ? "subtraction" : "multiplication";
+      arithmeticIssues.push({
+        function_name: nearestFunctionName(lines, i),
+        operation: opName,
+        suggestion: `Use checked_${opName.replace("tion", "").replace("rac", "sub")}() or the soroban_sdk overflow-safe helpers to avoid integer overflow.`,
+        location: `line ${lineNo}`,
+      });
+    }
+  }
+
+  // ── Pass 2: function-level auth gap detection ─────────────────────────────
+  // Collect all `pub fn` blocks and check if they mutate storage without require_auth
+  const pubFnRe = /\bpub\s+fn\s+(\w+)\s*\(/g;
+  let m: RegExpExecArray | null;
+  while ((m = pubFnRe.exec(source)) !== null) {
+    const fnName = m[1];
+    const bodyStart = source.indexOf("{", m.index);
+    if (bodyStart === -1) continue;
+
+    // Collect the function body by brace-matching
+    let depth = 0;
+    let bodyEnd = bodyStart;
+    for (let k = bodyStart; k < source.length; k++) {
+      if (source[k] === "{") depth++;
+      else if (source[k] === "}") {
+        depth--;
+        if (depth === 0) {
+          bodyEnd = k;
+          break;
+        }
+      }
+    }
+    const body = source.slice(bodyStart, bodyEnd + 1);
+
+    const mutatesStorage =
+      /env\.storage\(\)\s*\.\s*(instance|persistent|temporary)\s*\(\)\s*\.\s*set\b/.test(body) ||
+      /storage\(\)\s*\.\s*set\b/.test(body);
+
+    const hasAuth =
+      /require_auth|verify_auth|authorize|env\.require_auth/.test(body);
+
+    if (mutatesStorage && !hasAuth) {
+      // Find the line number of the fn keyword
+      const lineNo =
+        source.slice(0, m.index).split("\n").length;
+      authGaps.push(`line ${lineNo}: ${fnName}`);
+    }
+  }
+
+  return {
+    auth_gaps: authGaps,
+    panic_issues: panicIssues,
+    arithmetic_issues: deduplicateArithmetic(arithmeticIssues),
+    size_warnings: [],
+    unsafe_patterns: unsafePatterns,
+  };
+}
+
+function nearestFunctionName(lines: string[], fromIndex: number): string {
+  for (let i = fromIndex; i >= 0; i--) {
+    const m = lines[i].match(/\bfn\s+(\w+)\s*\(/);
+    if (m) return m[1];
+  }
+  return "<unknown>";
+}
+
+function deduplicateArithmetic(issues: ArithmeticIssue[]): ArithmeticIssue[] {
+  const seen = new Set<string>();
+  return issues.filter((issue) => {
+    const key = `${issue.function_name}:${issue.operation}:${issue.location}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
 }

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -106,6 +106,13 @@ export default function DashboardPage() {
         </div>
         <nav className="flex items-center gap-4" aria-label="Main navigation">
           <Link
+            href="/scan"
+            className="text-sm font-medium transition-colors focus:outline-none focus:ring-2"
+            style={{ color: "var(--muted-foreground)" }}
+          >
+            Scan
+          </Link>
+          <Link
             href="/terminal"
             className="text-sm font-medium transition-colors focus:outline-none focus:ring-2"
             style={{ color: "var(--muted-foreground)" }}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -20,16 +20,28 @@ export default function Home() {
         <p className="text-lg text-center max-w-md" style={{ color: "var(--muted-foreground)" }}>
           Stellar Soroban Security & Formal Verification Suite
         </p>
-        <Link
-          href="/dashboard"
-          className="rounded-lg px-6 py-3 font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2"
-          style={{
-            backgroundColor: "var(--primary)",
-            color: "var(--primary-foreground)",
-          }}
-        >
-          Open Security Dashboard
-        </Link>
+        <div className="flex flex-wrap justify-center gap-3">
+          <Link
+            href="/scan"
+            className="rounded-lg px-6 py-3 font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2"
+            style={{
+              backgroundColor: "var(--primary)",
+              color: "var(--primary-foreground)",
+            }}
+          >
+            Scan a Contract
+          </Link>
+          <Link
+            href="/dashboard"
+            className="rounded-lg border px-6 py-3 font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2"
+            style={{
+              borderColor: "var(--border)",
+              color: "var(--foreground)",
+            }}
+          >
+            Security Dashboard
+          </Link>
+        </div>
       </main>
     </div>
   );

--- a/frontend/app/scan/page.tsx
+++ b/frontend/app/scan/page.tsx
@@ -1,0 +1,557 @@
+"use client";
+
+import { useCallback, useRef, useState, Suspense } from "react";
+import Link from "next/link";
+import type { AnalysisReport, Finding } from "../types";
+import { transformReport } from "../lib/transform";
+import { FindingsPanel } from "../components/FindingsPanel";
+import { SanctityScore } from "../components/SanctityScore";
+import { SummaryChart } from "../components/SummaryChart";
+import { ThemeToggle } from "../components/ThemeToggle";
+import { ErrorBoundary } from "../components/ErrorBoundary";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MAX_BYTES = 512 * 1024;
+const ALLOWED_EXT = [".rs", ".zip"];
+const PLACEHOLDER = `// Paste your Soroban contract source here, e.g.:
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Env};
+
+#[contract]
+pub struct TokenContract;
+
+#[contractimpl]
+impl TokenContract {
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        // Missing require_auth → auth gap
+        env.storage().instance().set(&from, &(amount - 1)); // unchecked arithmetic
+    }
+}`;
+
+type InputTab = "paste" | "upload";
+type PageState = "idle" | "loading" | "results" | "error";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function bytesOf(s: string) {
+  return new TextEncoder().encode(s).length;
+}
+
+function validateFile(file: File): string | null {
+  const ext = "." + file.name.split(".").pop()?.toLowerCase();
+  if (!ALLOWED_EXT.includes(ext))
+    return `Only ${ALLOWED_EXT.join(", ")} files are accepted.`;
+  if (file.size > MAX_BYTES)
+    return `File too large — maximum size is ${Math.round(MAX_BYTES / 1024)} KB.`;
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function Spinner() {
+  return (
+    <svg
+      className="h-5 w-5 animate-spin"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8v8H4z"
+      />
+    </svg>
+  );
+}
+
+interface DropZoneProps {
+  file: File | null;
+  error: string | null;
+  onFile: (f: File) => void;
+}
+
+function DropZone({ file, error, onFile }: DropZoneProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [dragging, setDragging] = useState(false);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setDragging(false);
+      const dropped = e.dataTransfer.files[0];
+      if (dropped) onFile(dropped);
+    },
+    [onFile]
+  );
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const picked = e.target.files?.[0];
+      if (picked) onFile(picked);
+      e.target.value = "";
+    },
+    [onFile]
+  );
+
+  return (
+    <div className="space-y-3">
+      <div
+        role="button"
+        tabIndex={0}
+        aria-label="Drop zone — drag and drop a .rs or .zip file, or press Enter to browse"
+        onDragOver={(e) => {
+          e.preventDefault();
+          setDragging(true);
+        }}
+        onDragLeave={() => setDragging(false)}
+        onDrop={handleDrop}
+        onClick={() => inputRef.current?.click()}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            inputRef.current?.click();
+          }
+        }}
+        className={`flex cursor-pointer flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed px-6 py-14 text-center transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400 ${
+          dragging
+            ? "border-blue-500 bg-blue-500/5"
+            : error
+              ? "border-red-400 dark:border-red-500"
+              : "border-zinc-300 hover:border-zinc-400 dark:border-zinc-700 dark:hover:border-zinc-500"
+        }`}
+      >
+        <svg
+          width="36"
+          height="36"
+          viewBox="0 0 24 24"
+          fill="none"
+          aria-hidden="true"
+          className="text-zinc-400 dark:text-zinc-500"
+        >
+          <path
+            d="M12 16V8M12 8l-3 3M12 8l3 3"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          <path
+            d="M3 16.5V18a2 2 0 002 2h14a2 2 0 002-2v-1.5"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+          />
+        </svg>
+
+        {file ? (
+          <p className="text-sm font-medium text-zinc-800 dark:text-zinc-200">
+            {file.name}{" "}
+            <span className="font-normal text-zinc-500 dark:text-zinc-400">
+              ({Math.round(file.size / 1024)} KB)
+            </span>
+          </p>
+        ) : (
+          <>
+            <p className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+              Drag &amp; drop a <code className="font-mono">.rs</code> or{" "}
+              <code className="font-mono">.zip</code> file
+            </p>
+            <p className="text-xs text-zinc-500 dark:text-zinc-400">
+              or{" "}
+              <span className="underline underline-offset-2">browse files</span>{" "}
+              — max 512 KB
+            </p>
+          </>
+        )}
+
+        <input
+          ref={inputRef}
+          type="file"
+          accept=".rs,.zip"
+          className="sr-only"
+          onChange={handleChange}
+          aria-hidden="true"
+          tabIndex={-1}
+        />
+      </div>
+
+      {error && (
+        <p role="alert" className="text-sm text-red-600 dark:text-red-400">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export default function ScanPage() {
+  // Input state
+  const [tab, setTab] = useState<InputTab>("paste");
+  const [source, setSource] = useState("");
+  const [file, setFile] = useState<File | null>(null);
+  const [fileError, setFileError] = useState<string | null>(null);
+
+  // Page state
+  const [pageState, setPageState] = useState<PageState>("idle");
+  const [apiError, setApiError] = useState<string | null>(null);
+  const [findings, setFindings] = useState<Finding[]>([]);
+
+  // ── File selection ─────────────────────────────────────────────────────────
+  const handleFile = useCallback((f: File) => {
+    const err = validateFile(f);
+    setFileError(err);
+    setFile(err ? null : f);
+  }, []);
+
+  // ── Submit ─────────────────────────────────────────────────────────────────
+  const handleSubmit = useCallback(async () => {
+    setApiError(null);
+    setFindings([]);
+    setPageState("loading");
+
+    try {
+      let body: BodyInit;
+      const headers: Record<string, string> = {};
+
+      if (tab === "paste") {
+        if (!source.trim()) {
+          setApiError("Please paste some Rust source code before scanning.");
+          setPageState("idle");
+          return;
+        }
+        if (bytesOf(source) > MAX_BYTES) {
+          setApiError("Source exceeds the 512 KB limit.");
+          setPageState("idle");
+          return;
+        }
+        body = JSON.stringify({ source });
+        headers["Content-Type"] = "application/json";
+      } else {
+        if (!file) {
+          setApiError("Please select a file before scanning.");
+          setPageState("idle");
+          return;
+        }
+        const fd = new FormData();
+        fd.append("file", file);
+        body = fd;
+        // No Content-Type header — browser sets multipart boundary automatically
+      }
+
+      const res = await fetch("/api/analyze", {
+        method: "POST",
+        headers,
+        body,
+      });
+
+      const json = await res.json() as AnalysisReport & { error?: string };
+
+      if (!res.ok || json.error) {
+        setApiError(json.error ?? `Server error (${res.status})`);
+        setPageState("error");
+        return;
+      }
+
+      // Handle new CI/CD format with nested "findings" key
+      const report = (json as Record<string, unknown>).findings
+        ? ((json as Record<string, unknown>).findings as AnalysisReport)
+        : json;
+
+      const transformed = transformReport(report);
+      setFindings(transformed);
+      setPageState("results");
+    } catch (err) {
+      setApiError(
+        err instanceof Error ? err.message : "Unexpected error — please try again."
+      );
+      setPageState("error");
+    }
+  }, [tab, source, file]);
+
+  const canSubmit =
+    pageState !== "loading" &&
+    (tab === "paste" ? source.trim().length > 0 : file !== null);
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+  return (
+    <div
+      className="min-h-screen"
+      style={{
+        backgroundColor: "var(--background)",
+        color: "var(--foreground)",
+      }}
+    >
+      {/* Header */}
+      <header
+        className="flex flex-col gap-4 border-b px-4 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-6"
+        style={{ borderColor: "var(--border)", backgroundColor: "var(--card)" }}
+        role="banner"
+      >
+        <div className="flex items-center gap-4 sm:gap-6">
+          <Link
+            href="/"
+            className="text-lg font-bold focus:outline-none focus:ring-2"
+            style={{ color: "var(--foreground)" }}
+          >
+            Sanctifier
+          </Link>
+          <span className="text-sm sm:text-base" style={{ color: "var(--muted-foreground)" }}>
+            Scan Contract
+          </span>
+        </div>
+        <nav className="flex items-center gap-4" aria-label="Main navigation">
+          <Link
+            href="/dashboard"
+            className="text-sm font-medium transition-colors focus:outline-none focus:ring-2"
+            style={{ color: "var(--muted-foreground)" }}
+          >
+            Dashboard
+          </Link>
+          <Link
+            href="/terminal"
+            className="text-sm font-medium transition-colors focus:outline-none focus:ring-2"
+            style={{ color: "var(--muted-foreground)" }}
+          >
+            Live Terminal
+          </Link>
+          <ThemeToggle />
+        </nav>
+      </header>
+
+      <main id="main-content" className="mx-auto max-w-4xl space-y-8 px-4 py-8 sm:px-6">
+        {/* Hero */}
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Scan a Contract</h1>
+          <p className="mt-2 text-sm" style={{ color: "var(--muted-foreground)" }}>
+            Paste Rust source or upload a <code className="font-mono">.rs</code> /{" "}
+            <code className="font-mono">.zip</code> file — no install required.
+          </p>
+        </div>
+
+        {/* Input card */}
+        <section
+          className="rounded-xl border p-6 space-y-5"
+          style={{
+            borderColor: "var(--border)",
+            backgroundColor: "var(--card)",
+          }}
+          aria-label="Contract input"
+        >
+          {/* Tabs */}
+          <div
+            role="tablist"
+            aria-label="Input method"
+            className="flex gap-1 rounded-lg p-1"
+            style={{ backgroundColor: "var(--muted)" }}
+          >
+            {(["paste", "upload"] as InputTab[]).map((t) => (
+              <button
+                key={t}
+                role="tab"
+                aria-selected={tab === t}
+                aria-controls={`panel-${t}`}
+                id={`tab-${t}`}
+                onClick={() => setTab(t)}
+                className="flex-1 rounded-md px-4 py-1.5 text-sm font-medium transition-all focus:outline-none focus:ring-2 focus:ring-inset focus:ring-zinc-400"
+                style={
+                  tab === t
+                    ? {
+                        backgroundColor: "var(--background)",
+                        color: "var(--foreground)",
+                        boxShadow: "0 1px 3px 0 rgba(0,0,0,.1)",
+                      }
+                    : { color: "var(--muted-foreground)" }
+                }
+              >
+                {t === "paste" ? "Paste Source" : "Upload File"}
+              </button>
+            ))}
+          </div>
+
+          {/* Paste panel */}
+          <div
+            role="tabpanel"
+            id="panel-paste"
+            aria-labelledby="tab-paste"
+            hidden={tab !== "paste"}
+          >
+            <label className="sr-only" htmlFor="source-input">
+              Rust source code
+            </label>
+            <textarea
+              id="source-input"
+              value={source}
+              onChange={(e) => setSource(e.target.value)}
+              placeholder={PLACEHOLDER}
+              rows={16}
+              spellCheck={false}
+              className="w-full resize-y rounded-lg border p-4 font-mono text-xs leading-relaxed focus:outline-none focus:ring-2 focus:ring-zinc-400 dark:focus:ring-zinc-500"
+              style={{
+                borderColor: "var(--border)",
+                backgroundColor: "var(--background)",
+                color: "var(--foreground)",
+              }}
+            />
+            {source.length > 0 && (
+              <p
+                className="mt-1 text-right text-xs"
+                style={{ color: "var(--muted-foreground)" }}
+              >
+                {Math.round(bytesOf(source) / 1024)} / 512 KB
+              </p>
+            )}
+          </div>
+
+          {/* Upload panel */}
+          <div
+            role="tabpanel"
+            id="panel-upload"
+            aria-labelledby="tab-upload"
+            hidden={tab !== "upload"}
+          >
+            <DropZone file={file} error={fileError} onFile={handleFile} />
+          </div>
+
+          {/* Analyse button */}
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            className="flex w-full items-center justify-center gap-2 rounded-lg px-5 py-2.5 text-sm font-semibold transition-all disabled:cursor-not-allowed disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-offset-2"
+            style={{
+              backgroundColor: "var(--primary)",
+              color: "var(--primary-foreground)",
+            }}
+            aria-busy={pageState === "loading"}
+          >
+            {pageState === "loading" ? (
+              <>
+                <Spinner />
+                Analysing…
+              </>
+            ) : (
+              "Analyse →"
+            )}
+          </button>
+        </section>
+
+        {/* Error banner */}
+        {pageState === "error" && apiError && (
+          <div
+            role="alert"
+            className="rounded-xl border border-red-300 bg-red-50 px-5 py-4 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/40 dark:text-red-400"
+          >
+            <strong className="font-semibold">Analysis error: </strong>
+            {apiError}
+          </div>
+        )}
+
+        {/* Loading progress */}
+        {pageState === "loading" && (
+          <div
+            className="flex items-center gap-3 rounded-xl border px-5 py-4"
+            style={{
+              borderColor: "var(--border)",
+              backgroundColor: "var(--card)",
+              color: "var(--muted-foreground)",
+            }}
+            aria-live="polite"
+            aria-label="Analysing contract"
+          >
+            <Spinner />
+            <span className="text-sm">
+              Running static analysis — this usually takes under a second…
+            </span>
+          </div>
+        )}
+
+        {/* Results */}
+        {pageState === "results" && (
+          <ErrorBoundary>
+            <>
+              {findings.length === 0 ? (
+                <div
+                  className="rounded-xl border border-dashed px-6 py-14 text-center"
+                  style={{ borderColor: "var(--border)" }}
+                >
+                  <p
+                    className="text-sm font-medium"
+                    style={{ color: "var(--foreground)" }}
+                  >
+                    No issues found
+                  </p>
+                  <p
+                    className="mt-1 text-xs"
+                    style={{ color: "var(--muted-foreground)" }}
+                  >
+                    Great — the static analysis raised zero findings for this
+                    source.
+                  </p>
+                </div>
+              ) : (
+                <div className="space-y-6">
+                  <div className="flex items-center justify-between">
+                    <h2 className="text-xl font-semibold">Results</h2>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setPageState("idle");
+                        setFindings([]);
+                        setSource("");
+                        setFile(null);
+                      }}
+                      className="text-xs underline underline-offset-2 focus:outline-none"
+                      style={{ color: "var(--muted-foreground)" }}
+                    >
+                      Scan another
+                    </button>
+                  </div>
+
+                  <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+                    <SanctityScore findings={findings} />
+                    <SummaryChart findings={findings} />
+                  </div>
+
+                  <section aria-label="Findings">
+                    <Suspense
+                      fallback={
+                        <p
+                          className="py-6 text-center text-sm"
+                          style={{ color: "var(--muted-foreground)" }}
+                        >
+                          Loading findings…
+                        </p>
+                      }
+                    >
+                      <FindingsPanel findings={findings} />
+                    </Suspense>
+                  </section>
+                </div>
+              )}
+            </>
+          </ErrorBoundary>
+        )}
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Implements issue #374 — the `/scan` page is the primary zero-setup entry point that lets anyone paste or upload a Soroban contract and see findings instantly, with no CLI install required.

- **`/scan` page** — tabbed UI (Paste Source / Upload File), client-side validation, POST to `/api/analyze`, progress indicator, results table with `SanctityScore`, `SummaryChart`, and `FindingsPanel` (with detail drawer from #372)
- **`POST /api/analyze`** — new endpoint alongside the existing GET stream handler; accepts `application/json` (paste mode) or `multipart/form-data` (file upload); runs a lightweight JS static analyser mirroring sanctifier-core heuristics: panic/unwrap/expect detection, unchecked integer arithmetic, and auth-gap detection on `env.storage().set()` calls without `require_auth`; returns a full `AnalysisReport` consumed by the existing `transformReport` pipeline
- **Nav links** — "Scan a Contract" primary CTA on home page; "Scan" link in dashboard header

## Acceptance criteria

- [x] Tabbed input: paste (textarea) or drag-and-drop file upload
- [x] Client validation: type allowlist (`.rs`, `.zip`), 512 KB max size, friendly inline error messages
- [x] POST to `/api/analyze`; spinner + `aria-busy` during in-flight, then results table
- [x] API errors handled gracefully — red alert banner with the server message

## Test plan

- [ ] Navigate to `/scan` — "Paste Source" and "Upload File" tabs visible
- [ ] Paste this snippet and click **Analyse →**:
  ```rust
  pub fn transfer(env: Env, from: Address, amount: i128) {
      env.storage().instance().set(&from, &(amount - 1));
      let _ = something.unwrap();
  }
  ```
  → findings: auth gap, unsafe unwrap, unchecked subtraction
- [ ] Drag-and-drop a `.rs` file onto the drop zone → same analysis flow
- [ ] Upload a `.txt` file → "Only .rs, .zip files are accepted" shown before submit
- [ ] Upload a file > 512 KB → size error shown before submit
- [ ] Upload a `.zip` → 422 response; red banner with CLI fallback instructions
- [ ] Submit with empty textarea → inline message "Please paste some Rust source code"
- [ ] Clean source with no issues → "No issues found" empty state
- [ ] "Scan another" resets to the input form
- [ ] `npx tsc --noEmit` passes with zero errors

## Author

Committed by **Gbangbolaoluwagbemiga** — pushed via joelpeace48-cell fork.