### PR TITLE
feat: detect unsafe integer casts

### DIFF
--- a/tooling/sanctifier-core/src/lib.rs
+++ b/tooling/sanctifier-core/src/lib.rs
@@ -10,7 +10,7 @@ pub mod rules;
 #[cfg(feature = "smt")]
 pub mod smt;
 mod storage_collision;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use syn::spanned::Spanned;
 use syn::visit::{self, Visit};
 use syn::{parse_str, Fields, File, Item, Meta, Type};
@@ -932,6 +932,7 @@ impl Analyzer {
             issues: Vec::new(),
             current_fn: None,
             seen: HashSet::new(),
+            var_types: HashMap::new(),
         };
         visitor.visit_file(&file);
         visitor.issues

--- a/tooling/sanctifier-core/src/rules/arithmetic_overflow.rs
+++ b/tooling/sanctifier-core/src/rules/arithmetic_overflow.rs
@@ -280,8 +280,7 @@ fn collect_signature_int_types(sig: &syn::Signature) -> HashMap<String, IntType>
     sig.inputs
         .iter()
         .filter_map(|arg| match arg {
-            syn::FnArg::Typed(pat_ty) => pat_ident(&pat_ty.pat)
-                .and_then(|ident| int_type_from_type(&pat_ty.ty).map(|ty| (ident, ty))),
+            syn::FnArg::Typed(pat_ty) => pat_ident(&pat_ty.pat).zip(int_type_from_type(&pat_ty.ty)),
             syn::FnArg::Receiver(_) => None,
         })
         .collect()
@@ -289,8 +288,7 @@ fn collect_signature_int_types(sig: &syn::Signature) -> HashMap<String, IntType>
 
 fn local_int_binding(pat: &syn::Pat) -> Option<(String, IntType)> {
     match pat {
-        syn::Pat::Type(pat_ty) => pat_ident(&pat_ty.pat)
-            .and_then(|ident| int_type_from_type(&pat_ty.ty).map(|ty| (ident, ty))),
+        syn::Pat::Type(pat_ty) => pat_ident(&pat_ty.pat).zip(int_type_from_type(&pat_ty.ty)),
         _ => None,
     }
 }

--- a/tooling/sanctifier-core/src/rules/arithmetic_overflow.rs
+++ b/tooling/sanctifier-core/src/rules/arithmetic_overflow.rs
@@ -1,6 +1,6 @@
 use crate::rules::{Rule, RuleViolation, Severity};
 use crate::ArithmeticIssue;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use syn::spanned::Spanned;
 use syn::visit::Visit;
 use syn::{parse_str, File};
@@ -38,6 +38,7 @@ impl Rule for ArithmeticOverflowRule {
             issues: Vec::new(),
             current_fn: None,
             seen: HashSet::new(),
+            var_types: HashMap::new(),
         };
         visitor.visit_file(&file);
 
@@ -45,13 +46,23 @@ impl Rule for ArithmeticOverflowRule {
             .issues
             .into_iter()
             .map(|issue| {
-                RuleViolation::new(
-                    self.name(),
-                    Severity::Warning,
-                    format!("Unchecked '{}' operation could overflow", issue.operation),
-                    issue.location,
-                )
-                .with_suggestion(issue.suggestion)
+                if issue.operation.starts_with("as ") {
+                    RuleViolation::new(
+                        "SANCT_UNSAFE_CAST",
+                        Severity::Error,
+                        format!("Unsafe numeric cast detected: {}", issue.operation),
+                        issue.location,
+                    )
+                    .with_suggestion(issue.suggestion)
+                } else {
+                    RuleViolation::new(
+                        self.name(),
+                        Severity::Warning,
+                        format!("Unchecked '{}' operation could overflow", issue.operation),
+                        issue.location,
+                    )
+                    .with_suggestion(issue.suggestion)
+                }
             })
             .collect()
     }
@@ -65,9 +76,16 @@ pub(crate) struct ArithVisitor {
     pub(crate) issues: Vec<ArithmeticIssue>,
     pub(crate) current_fn: Option<String>,
     pub(crate) seen: HashSet<(String, String)>,
+    pub(crate) var_types: HashMap<String, IntType>,
 }
 
 // Redundant ArithmeticIssue struct removed
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct IntType {
+    signed: bool,
+    bits: u16,
+}
 
 impl ArithVisitor {
     fn classify_op(op: &syn::BinOp) -> Option<(&'static str, &'static str)> {
@@ -104,16 +122,29 @@ impl ArithVisitor {
 impl<'ast> Visit<'ast> for ArithVisitor {
     fn visit_impl_item_fn(&mut self, node: &'ast syn::ImplItemFn) {
         let prev = self.current_fn.take();
+        let prev_types = std::mem::take(&mut self.var_types);
         self.current_fn = Some(node.sig.ident.to_string());
+        self.var_types = collect_signature_int_types(&node.sig);
         syn::visit::visit_impl_item_fn(self, node);
         self.current_fn = prev;
+        self.var_types = prev_types;
     }
 
     fn visit_item_fn(&mut self, node: &'ast syn::ItemFn) {
         let prev = self.current_fn.take();
+        let prev_types = std::mem::take(&mut self.var_types);
         self.current_fn = Some(node.sig.ident.to_string());
+        self.var_types = collect_signature_int_types(&node.sig);
         syn::visit::visit_item_fn(self, node);
         self.current_fn = prev;
+        self.var_types = prev_types;
+    }
+
+    fn visit_local(&mut self, node: &'ast syn::Local) {
+        if let Some((ident, int_type)) = local_int_binding(&node.pat) {
+            self.var_types.insert(ident, int_type);
+        }
+        syn::visit::visit_local(self, node);
     }
 
     fn visit_expr_binary(&mut self, node: &'ast syn::ExprBinary) {
@@ -180,6 +211,38 @@ impl<'ast> Visit<'ast> for ArithVisitor {
         }
         syn::visit::visit_expr_call(self, node);
     }
+
+    fn visit_expr_cast(&mut self, node: &'ast syn::ExprCast) {
+        if let Some(fn_name) = self.current_fn.clone() {
+            if let (Some(source), Some(target)) = (
+                int_type_from_expr(&node.expr, &self.var_types),
+                int_type_from_type(&node.ty),
+            ) {
+                if is_lossy_cast(source, target) {
+                    let operation = format!("as {}", int_type_label(target));
+                    let key = (
+                        fn_name.clone(),
+                        format!("{}:{}", operation, node.span().start().line),
+                    );
+                    if !self.seen.contains(&key) {
+                        self.seen.insert(key);
+                        let line = node.span().start().line;
+                        self.issues.push(ArithmeticIssue {
+                            function_name: fn_name.clone(),
+                            operation: format!(
+                                "as {} from {}",
+                                int_type_label(target),
+                                int_type_label(source)
+                            ),
+                            suggestion: "Use TryInto/try_into and handle the conversion error instead of a lossy `as` cast".to_string(),
+                            location: format!("{}:{}", fn_name, line),
+                        });
+                    }
+                }
+            }
+        }
+        syn::visit::visit_expr_cast(self, node);
+    }
 }
 
 fn classify_math_method(method: &str) -> Option<String> {
@@ -211,6 +274,89 @@ fn is_string_literal(expr: &syn::Expr) -> bool {
             ..
         })
     )
+}
+
+fn collect_signature_int_types(sig: &syn::Signature) -> HashMap<String, IntType> {
+    sig.inputs
+        .iter()
+        .filter_map(|arg| match arg {
+            syn::FnArg::Typed(pat_ty) => pat_ident(&pat_ty.pat)
+                .and_then(|ident| int_type_from_type(&pat_ty.ty).map(|ty| (ident, ty))),
+            syn::FnArg::Receiver(_) => None,
+        })
+        .collect()
+}
+
+fn local_int_binding(pat: &syn::Pat) -> Option<(String, IntType)> {
+    match pat {
+        syn::Pat::Type(pat_ty) => pat_ident(&pat_ty.pat)
+            .and_then(|ident| int_type_from_type(&pat_ty.ty).map(|ty| (ident, ty))),
+        _ => None,
+    }
+}
+
+fn pat_ident(pat: &syn::Pat) -> Option<String> {
+    match pat {
+        syn::Pat::Ident(ident) => Some(ident.ident.to_string()),
+        _ => None,
+    }
+}
+
+fn int_type_from_expr(expr: &syn::Expr, var_types: &HashMap<String, IntType>) -> Option<IntType> {
+    match expr {
+        syn::Expr::Path(expr_path) if expr_path.path.segments.len() == 1 => expr_path
+            .path
+            .segments
+            .first()
+            .and_then(|segment| var_types.get(&segment.ident.to_string()).copied()),
+        syn::Expr::Lit(syn::ExprLit {
+            lit: syn::Lit::Int(lit),
+            ..
+        }) => int_type_from_str(lit.suffix()),
+        syn::Expr::Paren(paren) => int_type_from_expr(&paren.expr, var_types),
+        syn::Expr::Group(group) => int_type_from_expr(&group.expr, var_types),
+        _ => None,
+    }
+}
+
+fn int_type_from_type(ty: &syn::Type) -> Option<IntType> {
+    match ty {
+        syn::Type::Path(type_path) if type_path.path.segments.len() == 1 => type_path
+            .path
+            .segments
+            .first()
+            .and_then(|segment| int_type_from_str(&segment.ident.to_string())),
+        _ => None,
+    }
+}
+
+fn int_type_from_str(name: &str) -> Option<IntType> {
+    let (signed, bits) = match name {
+        "i8" => (true, 8),
+        "i16" => (true, 16),
+        "i32" => (true, 32),
+        "i64" => (true, 64),
+        "i128" => (true, 128),
+        "isize" => (true, usize::BITS as u16),
+        "u8" => (false, 8),
+        "u16" => (false, 16),
+        "u32" => (false, 32),
+        "u64" => (false, 64),
+        "u128" => (false, 128),
+        "usize" => (false, usize::BITS as u16),
+        _ => return None,
+    };
+
+    Some(IntType { signed, bits })
+}
+
+fn is_lossy_cast(source: IntType, target: IntType) -> bool {
+    target.bits < source.bits || target.signed != source.signed
+}
+
+fn int_type_label(ty: IntType) -> String {
+    let prefix = if ty.signed { "i" } else { "u" };
+    format!("{prefix}{}", ty.bits)
 }
 
 #[cfg(test)]
@@ -279,5 +425,52 @@ mod tests {
         "#;
         let violations = rule.check(source);
         assert_eq!(violations.len(), 0);
+    }
+
+    #[test]
+    fn test_flag_lossy_integer_casts() {
+        let rule = ArithmeticOverflowRule::new();
+        let source = r#"
+            fn convert(big: i128, balance: u64, signed: i64) {
+                let amount_u32 = big as u32;
+                let index_i32 = balance as i32;
+                let wrapped_u64 = signed as u64;
+            }
+        "#;
+
+        let violations = rule.check(source);
+
+        assert_eq!(violations.len(), 3);
+        assert!(violations
+            .iter()
+            .all(|v| v.rule_name == "SANCT_UNSAFE_CAST"));
+        assert!(violations.iter().all(|v| v.severity == Severity::Error));
+        assert!(violations
+            .iter()
+            .all(|v| v.message.contains("Unsafe numeric cast")));
+        assert!(violations.iter().all(|v| v
+            .suggestion
+            .as_deref()
+            .unwrap_or_default()
+            .contains("try_into")));
+    }
+
+    #[test]
+    fn test_ignore_widening_and_checked_conversions() {
+        let rule = ArithmeticOverflowRule::new();
+        let source = r#"
+            fn convert(small: u32, signed: i32) -> Result<u64, ()> {
+                let widened_u64 = small as u64;
+                let widened_i128 = signed as i128;
+                let checked_u32: u32 = signed.try_into().map_err(|_| ())?;
+                Ok(widened_u64 + checked_u32 as u64)
+            }
+        "#;
+
+        let violations = rule.check(source);
+
+        assert!(violations
+            .iter()
+            .all(|v| v.rule_name != "SANCT_UNSAFE_CAST"));
     }
 }

--- a/tooling/sanctifier-core/tests/fixtures/detectors/arithmetic_overflow.rs
+++ b/tooling/sanctifier-core/tests/fixtures/detectors/arithmetic_overflow.rs
@@ -3,6 +3,7 @@ use soroban_sdk::{contract, contractimpl, Env};
 
 // FIXTURE: arithmetic_overflow detector
 // Unchecked +, -, and *= operations that could overflow/underflow.
+// Unsafe integer `as` casts that narrow width or change signedness.
 
 #[contract]
 pub struct ArithmeticContract;
@@ -20,5 +21,21 @@ impl ArithmeticContract {
     pub fn accrue(_env: Env, mut total: u128, rate: u128) -> u128 {
         total *= rate;
         total
+    }
+
+    pub fn truncate_amount(_env: Env, amount: i128) -> u32 {
+        amount as u32
+    }
+
+    pub fn wrap_signed(_env: Env, amount: i64) -> u64 {
+        amount as u64
+    }
+
+    pub fn widen_safely(_env: Env, amount: u32) -> u64 {
+        amount as u64
+    }
+
+    pub fn checked_conversion(_env: Env, amount: i128) -> Result<u32, ()> {
+        amount.try_into().map_err(|_| ())
     }
 }

--- a/tooling/sanctifier-core/tests/snapshots/detector_snapshots__arithmetic_overflow.snap
+++ b/tooling/sanctifier-core/tests/snapshots/detector_snapshots__arithmetic_overflow.snap
@@ -5,15 +5,25 @@ expression: findings
 - rule_name: arithmetic_overflow
   severity: Warning
   message: "Unchecked '+' operation could overflow"
-  location: "deposit:13"
+  location: "deposit:14"
   suggestion: Use .checked_add(rhs) or .saturating_add(rhs) to handle overflow
 - rule_name: arithmetic_overflow
   severity: Warning
   message: "Unchecked '-' operation could overflow"
-  location: "withdraw:17"
+  location: "withdraw:18"
   suggestion: Use .checked_sub(rhs) or .saturating_sub(rhs) to handle underflow
 - rule_name: arithmetic_overflow
   severity: Warning
   message: "Unchecked '*=' operation could overflow"
-  location: "accrue:21"
+  location: "accrue:22"
   suggestion: "Replace a *= b with a = a.checked_mul(b).expect(\"overflow\")"
+- rule_name: SANCT_UNSAFE_CAST
+  severity: Error
+  message: "Unsafe numeric cast detected: as u32 from i128"
+  location: "truncate_amount:27"
+  suggestion: "Use TryInto/try_into and handle the conversion error instead of a lossy `as` cast"
+- rule_name: SANCT_UNSAFE_CAST
+  severity: Error
+  message: "Unsafe numeric cast detected: as u64 from i64"
+  location: "wrap_signed:31"
+  suggestion: "Use TryInto/try_into and handle the conversion error instead of a lossy `as` cast"


### PR DESCRIPTION
Closes #321.

## Summary
- add `SANCT_UNSAFE_CAST` findings for integer `as` casts that narrow width or change signedness
- track explicit integer types from function parameters and typed local bindings before comparing cast source/target width and signedness
- keep widening casts and checked `try_into` conversions clean
- extend the arithmetic detector fixture and snapshot with lossy and safe conversion examples

## Validation
- `cargo test -p sanctifier-core --lib --no-default-features`
- `cargo test -p sanctifier-core --test detector_snapshots --no-default-features`
- `cargo check -p sanctifier-core --no-default-features`
- `git diff --check`

Note: default-feature local test/check attempts require the Z3 C headers; this machine is missing `z3.h`, so validation used the no-default-features core path for this detector change.
