### PR TITLE
feat: detect missing storage TTL bumps

### DIFF
--- a/tooling/sanctifier-core/src/rules/missing_ttl.rs
+++ b/tooling/sanctifier-core/src/rules/missing_ttl.rs
@@ -1,0 +1,304 @@
+use crate::rules::{Rule, RuleViolation, Severity};
+use syn::spanned::Spanned;
+use syn::visit::Visit;
+use syn::{parse_str, File};
+
+const FINDING_CODE: &str = "SANCT_TTL_MISSING";
+
+/// Detects persistent/instance storage accesses that do not extend the same key's TTL.
+pub struct MissingTtlRule;
+
+impl MissingTtlRule {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn check_function(&self, fn_name: &str, block: &syn::Block) -> Vec<RuleViolation> {
+        let mut visitor = StorageTtlVisitor::default();
+        visitor.visit_block(block);
+
+        visitor
+            .accesses
+            .into_iter()
+            .filter(|access| !visitor.bumps.iter().any(|bump| bump.covers(access)))
+            .map(|access| {
+                RuleViolation::new(
+                    FINDING_CODE,
+                    Severity::Warning,
+                    access.message(),
+                    format!("{}:{}", fn_name, access.line),
+                )
+                .with_suggestion(access.suggestion())
+            })
+            .collect()
+    }
+}
+
+impl Default for MissingTtlRule {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for MissingTtlRule {
+    fn name(&self) -> &str {
+        "missing_ttl"
+    }
+
+    fn description(&self) -> &str {
+        "Detects persistent/instance storage access without a matching TTL extension"
+    }
+
+    fn check(&self, source: &str) -> Vec<RuleViolation> {
+        let file = match parse_str::<File>(source) {
+            Ok(file) => file,
+            Err(_) => return vec![],
+        };
+
+        let mut visitor = MissingTtlRuleVisitor {
+            rule: self,
+            violations: Vec::new(),
+        };
+        visitor.visit_file(&file);
+        visitor.violations
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+struct MissingTtlRuleVisitor<'rule> {
+    rule: &'rule MissingTtlRule,
+    violations: Vec<RuleViolation>,
+}
+
+impl<'ast> Visit<'ast> for MissingTtlRuleVisitor<'_> {
+    fn visit_impl_item_fn(&mut self, node: &'ast syn::ImplItemFn) {
+        self.violations.extend(
+            self.rule
+                .check_function(&node.sig.ident.to_string(), &node.block),
+        );
+        syn::visit::visit_impl_item_fn(self, node);
+    }
+
+    fn visit_item_fn(&mut self, node: &'ast syn::ItemFn) {
+        self.violations.extend(
+            self.rule
+                .check_function(&node.sig.ident.to_string(), &node.block),
+        );
+        syn::visit::visit_item_fn(self, node);
+    }
+}
+
+#[derive(Default)]
+struct StorageTtlVisitor {
+    accesses: Vec<StorageAccess>,
+    bumps: Vec<StorageBump>,
+}
+
+impl<'ast> Visit<'ast> for StorageTtlVisitor {
+    fn visit_expr_method_call(&mut self, node: &'ast syn::ExprMethodCall) {
+        if let Some(kind) = storage_kind(&node.receiver) {
+            if let Some(key_expr) = node.args.first() {
+                let method = node.method.to_string();
+                if is_ttl_bump_method(&method) {
+                    self.bumps.push(StorageBump::new(kind, key_expr));
+                } else if is_durable_access_method(&method) {
+                    self.accesses.push(StorageAccess::new(
+                        kind,
+                        key_expr,
+                        method,
+                        node.span().start().line,
+                    ));
+                }
+            }
+        }
+
+        syn::visit::visit_expr_method_call(self, node);
+    }
+}
+
+#[derive(Debug, Clone)]
+struct StorageAccess {
+    kind: StorageKind,
+    key: Option<String>,
+    display_key: String,
+    method: String,
+    line: usize,
+}
+
+impl StorageAccess {
+    fn new(kind: StorageKind, key_expr: &syn::Expr, method: String, line: usize) -> Self {
+        Self {
+            kind,
+            key: durable_key(kind, key_expr),
+            display_key: display_key(key_expr),
+            method,
+            line,
+        }
+    }
+
+    fn message(&self) -> String {
+        match self.kind {
+            StorageKind::Persistent => format!(
+                "SANCT_TTL_MISSING: persistent storage `{}` for key `{}` does not extend TTL",
+                self.method, self.display_key
+            ),
+            StorageKind::Instance => format!(
+                "SANCT_TTL_MISSING: instance storage `{}` for key `{}` does not extend TTL",
+                self.method, self.display_key
+            ),
+        }
+    }
+
+    fn suggestion(&self) -> String {
+        match self.kind {
+            StorageKind::Persistent => format!(
+                "Call `env.storage().persistent().extend_ttl(&{}, LOW, HIGH)` after accessing this durable entry",
+                self.display_key
+            ),
+            StorageKind::Instance => {
+                "Call `env.storage().instance().extend_ttl(LOW, HIGH)` after accessing instance storage".to_string()
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct StorageBump {
+    kind: StorageKind,
+    key: Option<String>,
+}
+
+impl StorageBump {
+    fn new(kind: StorageKind, key_expr: &syn::Expr) -> Self {
+        Self {
+            kind,
+            key: durable_key(kind, key_expr),
+        }
+    }
+
+    fn covers(&self, access: &StorageAccess) -> bool {
+        if self.kind != access.kind {
+            return false;
+        }
+
+        match self.kind {
+            StorageKind::Persistent => self.key == access.key,
+            StorageKind::Instance => true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StorageKind {
+    Persistent,
+    Instance,
+}
+
+fn is_durable_access_method(method: &str) -> bool {
+    matches!(method, "get" | "set" | "update" | "remove" | "has")
+}
+
+fn is_ttl_bump_method(method: &str) -> bool {
+    method == "extend_ttl" || method.contains("bump")
+}
+
+fn storage_kind(expr: &syn::Expr) -> Option<StorageKind> {
+    match expr {
+        syn::Expr::MethodCall(method_call) if method_call.method == "persistent" => {
+            Some(StorageKind::Persistent)
+        }
+        syn::Expr::MethodCall(method_call) if method_call.method == "instance" => {
+            Some(StorageKind::Instance)
+        }
+        syn::Expr::MethodCall(method_call) => storage_kind(&method_call.receiver),
+        _ => None,
+    }
+}
+
+fn durable_key(kind: StorageKind, expr: &syn::Expr) -> Option<String> {
+    match kind {
+        StorageKind::Persistent => Some(display_key(expr).split_whitespace().collect()),
+        StorageKind::Instance => None,
+    }
+}
+
+fn display_key(expr: &syn::Expr) -> String {
+    let key_expr = match expr {
+        syn::Expr::Reference(reference) => reference.expr.as_ref(),
+        _ => expr,
+    };
+    quote::quote!(#key_expr).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_persistent_access_without_ttl_extension() {
+        let source = r#"
+            impl Contract {
+                pub fn write(env: Env, key: Symbol, value: i128) {
+                    env.storage().persistent().set(&key, &value);
+                }
+            }
+        "#;
+
+        let findings = MissingTtlRule::new().check(source);
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_name, "SANCT_TTL_MISSING");
+        assert!(findings[0].message.contains("SANCT_TTL_MISSING"));
+    }
+
+    #[test]
+    fn accepts_matching_ttl_extension_for_same_key_and_kind() {
+        let source = r#"
+            impl Contract {
+                pub fn write(env: Env, key: Symbol, value: i128) {
+                    env.storage().persistent().set(&key, &value);
+                    env.storage().persistent().extend_ttl(&key, 100, 1000);
+                }
+            }
+        "#;
+
+        let findings = MissingTtlRule::new().check(source);
+
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn requires_extension_on_same_storage_kind() {
+        let source = r#"
+            impl Contract {
+                pub fn write(env: Env, key: Symbol, value: i128) {
+                    env.storage().persistent().set(&key, &value);
+                    env.storage().instance().extend_ttl(&key, 100, 1000);
+                }
+            }
+        "#;
+
+        let findings = MissingTtlRule::new().check(source);
+
+        assert_eq!(findings.len(), 1);
+    }
+
+    #[test]
+    fn accepts_instance_ttl_extension_without_key_match() {
+        let source = r#"
+            impl Contract {
+                pub fn write(env: Env, key: Symbol, value: i128) {
+                    env.storage().instance().set(&key, &value);
+                    env.storage().instance().extend_ttl(100, 1000);
+                }
+            }
+        "#;
+
+        let findings = MissingTtlRule::new().check(source);
+
+        assert!(findings.is_empty());
+    }
+}

--- a/tooling/sanctifier-core/src/rules/mod.rs
+++ b/tooling/sanctifier-core/src/rules/mod.rs
@@ -5,6 +5,7 @@ pub mod error_code_collision;
 pub mod fee_rounding;
 pub mod hardcoded_addr;
 pub mod ledger_size;
+pub mod missing_ttl;
 pub mod panic_detection;
 pub mod unhandled_result;
 pub mod unused_variable;
@@ -125,6 +126,7 @@ impl RuleRegistry {
         registry.register(error_code_collision::ErrorCodeCollisionRule::new());
         registry.register(edge_amount::EdgeAmountRule::new());
         registry.register(fee_rounding::FeeRoundingRule::new());
+        registry.register(missing_ttl::MissingTtlRule::new());
         registry
     }
 }

--- a/tooling/sanctifier-core/tests/detector_snapshots.rs
+++ b/tooling/sanctifier-core/tests/detector_snapshots.rs
@@ -16,8 +16,8 @@ use sanctifier_core::rules::{
     arithmetic_overflow::ArithmeticOverflowRule, auth_gap::AuthGapRule,
     edge_amount::EdgeAmountRule, error_code_collision::ErrorCodeCollisionRule,
     fee_rounding::FeeRoundingRule, hardcoded_addr::HardcodedAddrRule, ledger_size::LedgerSizeRule,
-    panic_detection::PanicDetectionRule, unhandled_result::UnhandledResultRule,
-    unused_variable::UnusedVariableRule, Rule,
+    missing_ttl::MissingTtlRule, panic_detection::PanicDetectionRule,
+    unhandled_result::UnhandledResultRule, unused_variable::UnusedVariableRule, Rule,
 };
 
 /// Run a detector against its fixture and snapshot the resulting findings.
@@ -116,5 +116,14 @@ fn snapshot_fee_rounding() {
         "fee_rounding",
         &FeeRoundingRule::new(),
         include_str!("fixtures/detectors/fee_rounding.rs"),
+    );
+}
+
+#[test]
+fn snapshot_missing_ttl() {
+    assert_detector_snapshot(
+        "missing_ttl",
+        &MissingTtlRule::new(),
+        include_str!("fixtures/detectors/missing_ttl.rs"),
     );
 }

--- a/tooling/sanctifier-core/tests/fixtures/corpus/differential-corpus.json
+++ b/tooling/sanctifier-core/tests/fixtures/corpus/differential-corpus.json
@@ -18,7 +18,9 @@
     "edge_amount": "S013",
     "unused_variable": "S015",
     "error_code_collision": "S016",
-    "fee_rounding": "S017"
+    "fee_rounding": "S017",
+    "missing_ttl": "S006",
+    "SANCT_TTL_MISSING": "S006"
   },
   "overlap_legend": {
     "shared-covered": "Class has an EVM analogue and Sanctifier already flags it.",
@@ -77,11 +79,11 @@
       "title": "Missing storage TTL bump (state archival)",
       "soroban": { "vulnerable": "missing_ttl_vulnerable.rs", "fixed": "missing_ttl_fixed.rs" },
       "solidity": null,
-      "sanctifier": { "ideal_code": "S006", "observed_codes": [], "status": "planned" },
+      "sanctifier": { "ideal_code": "S006", "observed_codes": ["S006"], "status": "flagged" },
       "slither": { "detectors": [], "expected": false },
       "aderyn": { "detectors": [], "expected": false },
       "overlap": "soroban-specific",
-      "notes": "Soroban archives ledger entries whose TTL is not extended. There is no EVM analogue, so neither Slither nor Aderyn can have an equivalent check. Sanctifier should own this class (planned S006)."
+      "notes": "Soroban archives ledger entries whose TTL is not extended. There is no EVM analogue, so neither Slither nor Aderyn can have an equivalent check. Sanctifier now flags direct persistent/instance storage access that lacks a matching TTL extension."
     },
     {
       "bug_class": "weak_randomness",

--- a/tooling/sanctifier-core/tests/fixtures/detectors/missing_ttl.rs
+++ b/tooling/sanctifier-core/tests/fixtures/detectors/missing_ttl.rs
@@ -1,0 +1,23 @@
+use soroban_sdk::{Address, Env, Symbol};
+
+struct Contract;
+
+impl Contract {
+    pub fn write_without_ttl(env: Env, key: Symbol, value: i128) {
+        env.storage().persistent().set(&key, &value);
+    }
+
+    pub fn read_without_ttl(env: Env, owner: Address) -> i128 {
+        env.storage().persistent().get(&owner).unwrap_or(0)
+    }
+
+    pub fn write_with_ttl(env: Env, key: Symbol, value: i128) {
+        env.storage().persistent().set(&key, &value);
+        env.storage().persistent().extend_ttl(&key, 100, 1000);
+    }
+
+    pub fn instance_with_ttl(env: Env, key: Symbol, value: i128) {
+        env.storage().instance().set(&key, &value);
+        env.storage().instance().extend_ttl(100, 1000);
+    }
+}

--- a/tooling/sanctifier-core/tests/fixtures/gallery/README.md
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/README.md
@@ -18,7 +18,7 @@ are not compiled or deployed.
 | 2 | Unchecked upgrade auth | `S010` upgrade_risk | `upgrade_auth_vulnerable.rs` | `upgrade_auth_fixed.rs` | ⚠️ surfaced via `S001` auth_gap |
 | 3 | CEI / reentrancy | `S006` unsafe_pattern | `reentrancy_vulnerable.rs` | `reentrancy_fixed.rs` | 🔜 planned detector |
 | 4 | Unbounded loop | `S006` unsafe_pattern | `unbounded_loop_vulnerable.rs` | `unbounded_loop_fixed.rs` | 🔜 planned detector |
-| 5 | Missing TTL bump | `S006` unsafe_pattern | `missing_ttl_vulnerable.rs` | `missing_ttl_fixed.rs` | 🔜 planned detector |
+| 5 | Missing TTL bump | `S006` unsafe_pattern | `missing_ttl_vulnerable.rs` | `missing_ttl_fixed.rs` | ✅ default detector |
 | 6 | Weak randomness | `S006` unsafe_pattern | `weak_randomness_vulnerable.rs` | `weak_randomness_fixed.rs` | 🔜 planned detector |
 | 7 | Integer overflow | `S003` arithmetic_overflow | `integer_overflow_vulnerable.rs` | `integer_overflow_fixed.rs` | ✅ flagged today |
 | 8 | Allowance race (TOCTOU) | `S006` unsafe_pattern | `allowance_race_vulnerable.rs` | `allowance_race_fixed.rs` | 🔜 planned detector |

--- a/tooling/sanctifier-core/tests/fixtures/gallery/allowance_race_fixed.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/allowance_race_fixed.rs
@@ -24,8 +24,16 @@ impl AllowanceRaceFixed {
             .persistent()
             .get(&(owner.clone(), spender.clone()))
             .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .extend_ttl(&(owner.clone(), spender.clone()), 100, 1000);
         if stored == expected_current {
-            env.storage().persistent().set(&(owner, spender), &amount);
+            env.storage()
+                .persistent()
+                .set(&(owner.clone(), spender.clone()), &amount);
+            env.storage()
+                .persistent()
+                .extend_ttl(&(owner.clone(), spender.clone()), 100, 1000);
         }
     }
 }

--- a/tooling/sanctifier-core/tests/fixtures/gallery/allowance_race_vulnerable.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/allowance_race_vulnerable.rs
@@ -13,6 +13,11 @@ impl AllowanceRaceVulnerable {
     // the change and spend the old allowance plus the new one (ERC20-style race).
     pub fn approve(env: Env, owner: Address, spender: Address, amount: i128) {
         owner.require_auth();
-        env.storage().persistent().set(&(owner, spender), &amount);
+        env.storage()
+            .persistent()
+            .set(&(owner.clone(), spender.clone()), &amount);
+        env.storage()
+            .persistent()
+            .extend_ttl(&(owner.clone(), spender.clone()), 100, 1000);
     }
 }

--- a/tooling/sanctifier-core/tests/fixtures/gallery/confused_deputy_fixed.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/confused_deputy_fixed.rs
@@ -14,7 +14,9 @@ impl ConfusedDeputyFixed {
         owner.require_auth();
         let bal: i128 = env.storage().persistent().get(&owner).unwrap_or(0);
         env.storage().persistent().set(&owner, &bal.saturating_sub(amount));
+        env.storage().persistent().extend_ttl(&owner, 100, 1000);
         let to_bal: i128 = env.storage().persistent().get(&to).unwrap_or(0);
         env.storage().persistent().set(&to, &to_bal.saturating_add(amount));
+        env.storage().persistent().extend_ttl(&to, 100, 1000);
     }
 }

--- a/tooling/sanctifier-core/tests/fixtures/gallery/confused_deputy_vulnerable.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/confused_deputy_vulnerable.rs
@@ -16,7 +16,9 @@ impl ConfusedDeputyVulnerable {
         caller.require_auth();
         let bal: i128 = env.storage().persistent().get(&owner).unwrap_or(0);
         env.storage().persistent().set(&owner, &bal.saturating_sub(amount));
+        env.storage().persistent().extend_ttl(&owner, 100, 1000);
         let to_bal: i128 = env.storage().persistent().get(&to).unwrap_or(0);
         env.storage().persistent().set(&to, &to_bal.saturating_add(amount));
+        env.storage().persistent().extend_ttl(&to, 100, 1000);
     }
 }

--- a/tooling/sanctifier-core/tests/fixtures/gallery/integer_overflow_fixed.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/integer_overflow_fixed.rs
@@ -14,5 +14,6 @@ impl IntegerOverflowFixed {
         let balance: i128 = env.storage().persistent().get(&user).unwrap_or(0);
         let new_balance = balance.checked_add(amount).unwrap_or(balance);
         env.storage().persistent().set(&user, &new_balance);
+        env.storage().persistent().extend_ttl(&user, 100, 1000);
     }
 }

--- a/tooling/sanctifier-core/tests/fixtures/gallery/integer_overflow_vulnerable.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/integer_overflow_vulnerable.rs
@@ -14,5 +14,6 @@ impl IntegerOverflowVulnerable {
         let balance: i128 = env.storage().persistent().get(&user).unwrap_or(0);
         let new_balance = balance + amount;
         env.storage().persistent().set(&user, &new_balance);
+        env.storage().persistent().extend_ttl(&user, 100, 1000);
     }
 }

--- a/tooling/sanctifier-core/tests/fixtures/gallery/oracle_staleness_fixed.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/oracle_staleness_fixed.rs
@@ -14,6 +14,7 @@ impl OracleStalenessFixed {
         const MAX_AGE: u64 = 300;
         let (price, updated_at): (i128, u64) =
             env.storage().persistent().get(&asset).unwrap_or((0, 0));
+        env.storage().persistent().extend_ttl(&asset, 100, 1000);
         let age = env.ledger().timestamp().saturating_sub(updated_at);
         if age > MAX_AGE {
             return 0;

--- a/tooling/sanctifier-core/tests/fixtures/gallery/oracle_staleness_vulnerable.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/oracle_staleness_vulnerable.rs
@@ -13,6 +13,7 @@ impl OracleStalenessVulnerable {
     // expired price can be used for critical pricing/liquidation math.
     pub fn get_price(env: Env, asset: Symbol) -> i128 {
         let price: i128 = env.storage().persistent().get(&asset).unwrap_or(0);
+        env.storage().persistent().extend_ttl(&asset, 100, 1000);
         price
     }
 }

--- a/tooling/sanctifier-core/tests/fixtures/gallery/reentrancy_fixed.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/reentrancy_fixed.rs
@@ -18,6 +18,7 @@ impl ReentrancyFixed {
         let balance: i128 = env.storage().persistent().get(&user).unwrap_or(0);
         let remaining = balance.saturating_sub(amount);
         env.storage().persistent().set(&user, &remaining);
+        env.storage().persistent().extend_ttl(&user, 100, 1000);
         env.events().publish((PAID,), (user.clone(), amount));
     }
 }

--- a/tooling/sanctifier-core/tests/fixtures/gallery/reentrancy_vulnerable.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/reentrancy_vulnerable.rs
@@ -19,5 +19,6 @@ impl ReentrancyVulnerable {
         env.events().publish((PAID,), (user.clone(), amount));
         let remaining = balance.saturating_sub(amount);
         env.storage().persistent().set(&user, &remaining);
+        env.storage().persistent().extend_ttl(&user, 100, 1000);
     }
 }

--- a/tooling/sanctifier-core/tests/fixtures/gallery/reinit_fixed.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/reinit_fixed.rs
@@ -17,5 +17,6 @@ impl ReinitFixed {
         if existing.is_none() {
             env.storage().instance().set(&ADMIN, &admin);
         }
+        env.storage().instance().extend_ttl(100, 1000);
     }
 }

--- a/tooling/sanctifier-core/tests/fixtures/gallery/reinit_vulnerable.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/reinit_vulnerable.rs
@@ -15,5 +15,6 @@ impl ReinitVulnerable {
     // overwrite the admin. Mutates storage with no prior read and no auth.
     pub fn initialize(env: Env, admin: Address) {
         env.storage().instance().set(&ADMIN, &admin);
+        env.storage().instance().extend_ttl(100, 1000);
     }
 }

--- a/tooling/sanctifier-core/tests/fixtures/gallery/upgrade_auth_fixed.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/upgrade_auth_fixed.rs
@@ -15,5 +15,6 @@ impl UpgradeAuthFixed {
     pub fn set_upgrade_admin(env: Env, caller: Address, new_admin: Address) {
         caller.require_auth();
         env.storage().instance().set(&ADMIN, &new_admin);
+        env.storage().instance().extend_ttl(100, 1000);
     }
 }

--- a/tooling/sanctifier-core/tests/fixtures/gallery/upgrade_auth_vulnerable.rs
+++ b/tooling/sanctifier-core/tests/fixtures/gallery/upgrade_auth_vulnerable.rs
@@ -16,5 +16,6 @@ impl UpgradeAuthVulnerable {
     // the privileged write has no require_auth() gate.
     pub fn set_upgrade_admin(env: Env, new_admin: Address) {
         env.storage().instance().set(&ADMIN, &new_admin);
+        env.storage().instance().extend_ttl(100, 1000);
     }
 }

--- a/tooling/sanctifier-core/tests/snapshots/detector_snapshots__missing_ttl.snap
+++ b/tooling/sanctifier-core/tests/snapshots/detector_snapshots__missing_ttl.snap
@@ -1,0 +1,14 @@
+---
+source: tooling/sanctifier-core/tests/detector_snapshots.rs
+expression: findings
+---
+- rule_name: SANCT_TTL_MISSING
+  severity: Warning
+  message: "SANCT_TTL_MISSING: persistent storage `set` for key `key` does not extend TTL"
+  location: "write_without_ttl:7"
+  suggestion: "Call `env.storage().persistent().extend_ttl(&key, LOW, HIGH)` after accessing this durable entry"
+- rule_name: SANCT_TTL_MISSING
+  severity: Warning
+  message: "SANCT_TTL_MISSING: persistent storage `get` for key `owner` does not extend TTL"
+  location: "read_without_ttl:11"
+  suggestion: "Call `env.storage().persistent().extend_ttl(&owner, LOW, HIGH)` after accessing this durable entry"

--- a/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__missing_ttl_vulnerable.snap
+++ b/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__missing_ttl_vulnerable.snap
@@ -2,4 +2,8 @@
 source: tooling/sanctifier-core/tests/gallery_snapshots.rs
 expression: findings
 ---
-[]
+- rule_name: SANCT_TTL_MISSING
+  severity: Warning
+  message: "SANCT_TTL_MISSING: persistent storage `set` for key `key` does not extend TTL"
+  location: "store:16"
+  suggestion: "Call `env.storage().persistent().extend_ttl(&key, LOW, HIGH)` after accessing this durable entry"


### PR DESCRIPTION
## Summary of the change
Adds a default `missing_ttl` core rule that emits `SANCT_TTL_MISSING` when direct persistent or instance storage access lacks a matching TTL bump. Persistent storage bumps are matched by key; instance storage bumps are treated as covering the whole instance, matching Soroban semantics.

The detector is wired into the default registry with dedicated detector fixtures and snapshots. The vulnerability gallery and differential corpus are updated so the missing-TTL case is now flagged while the other gallery examples stay isolated from TTL findings.

## Fixes / Closes
Closes #315

## Motivation and context
Durable Soroban storage can be archived when TTL is not extended, so reads can later trap or require restoration. This adds a focused detector for direct `persistent()` / `instance()` storage access patterns that omit `extend_ttl` / bump calls.

## Dependencies
- No new Rust dependencies.
- CI already installs `libz3-dev` before `cargo test -p sanctifier-core --all-features`. This local environment does not have Z3 installed, so local validation used the no-default-features path documented by the test harness.

## Type of change
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## How Has This Been Tested?

- `cargo fmt --check`
- `cargo test -p sanctifier-core --no-default-features --lib`
- `cargo test -p sanctifier-core --no-default-features --test detector_snapshots`
- `cargo test -p sanctifier-core --no-default-features --test gallery_snapshots`
- `cargo test -p sanctifier-core --no-default-features --test differential_test`
- `git diff --check`

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
