### PR TITLE
[FV] CI job: run Kani proofs on PRs with a time budget (#348)

### DIFF
--- a/.github/workflows/fv-kani.yml
+++ b/.github/workflows/fv-kani.yml
@@ -1,0 +1,100 @@
+name: Formal Verification (Kani)
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+# Non-blocking initially (#348): this job runs every Kani harness with a
+# per-harness time budget and reports a pass/fail summary, but it never fails
+# the build while the proof suite stabilizes. Flip the `exit 0` / step
+# `continue-on-error` to make it blocking once the harnesses are reliably green.
+jobs:
+  kani:
+    name: Kani proofs (non-blocking)
+    runs-on: ubuntu-latest
+    # Hard ceiling so a runaway solver can never hang CI.
+    timeout-minutes: 30
+    env:
+      # Per-harness wall-clock budget handed to Kani.
+      HARNESS_TIMEOUT: 120s
+      # Crates that contain `#[cfg(kani)]` proof harnesses.
+      KANI_PACKAGES: kani-poc-contract token-invariants amm-pool reentrancy-guard
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      # Cache the Kani toolchain (~/.kani), the installed verifier binary, the
+      # cargo registry, and build artifacts so reruns stay fast.
+      - name: Cache Kani toolchain & cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.kani/
+            target/
+          key: ${{ runner.os }}-kani-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-kani-
+
+      - name: Install Kani
+        continue-on-error: true
+        run: |
+          if ! command -v cargo-kani >/dev/null 2>&1; then
+            cargo install --locked kani-verifier
+          fi
+          # Idempotent: fetches the backend once, then is a fast no-op when cached.
+          cargo kani setup
+
+      - name: Run Kani harnesses (per-harness time budget)
+        id: kani
+        continue-on-error: true
+        run: |
+          set +e
+          {
+            echo "## 🔬 Kani formal verification"
+            echo ""
+            echo "Per-harness time budget: \`${HARNESS_TIMEOUT}\`"
+            echo ""
+            echo "| Package | Result |"
+            echo "| ------- | ------ |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          overall=0
+          for pkg in $KANI_PACKAGES; do
+            echo "::group::cargo kani -p ${pkg}"
+            # `--harness-timeout` budgets each harness; the outer `timeout` is a
+            # belt-and-suspenders wall-clock cap on the whole package run.
+            timeout 900 cargo kani \
+              -p "${pkg}" \
+              --harness-timeout "${HARNESS_TIMEOUT}" \
+              --output-format terse
+            rc=$?
+            echo "::endgroup::"
+            if [ "${rc}" -eq 0 ]; then
+              echo "| \`${pkg}\` | ✅ pass |" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "| \`${pkg}\` | ⚠️ fail/timeout (exit ${rc}) |" >> "$GITHUB_STEP_SUMMARY"
+              overall=1
+            fi
+          done
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${overall}" -eq 0 ]; then
+            echo "All Kani harnesses verified ✅" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "> Some harnesses did not verify. This job is **non-blocking** for now (#348)." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          # Non-blocking: report results without failing the build.
+          exit 0


### PR DESCRIPTION
Closes #348

## Summary

Adds a GitHub Actions job that runs `cargo kani` on the proof-harness crates with a **per-harness time budget** and a pass/fail summary — the "we verify in CI" guard the issue asks for, keeping formal guarantees from silently regressing.

## What it does (`.github/workflows/fv-kani.yml`)
- Runs Kani on every crate that has `#[cfg(kani)]` harnesses: **`kani-poc-contract`, `token-invariants`, `amm-pool`, `reentrancy-guard`**, each with `--harness-timeout 120s` (plus an outer wall-clock cap per package).
- **Caches the Kani toolchain** (`~/.kani`), the verifier binary, the cargo registry, and `target/` so reruns stay fast.
- **Summarizes pass/fail per package** in the GitHub step summary (`$GITHUB_STEP_SUMMARY`).
- **Non-blocking initially** (as the issue specifies): the install + proof steps are `continue-on-error` and the runner exits 0, so the job reports results without blocking merges while the suite stabilizes. `timeout-minutes: 30` caps a runaway solver.

## Acceptance criteria
- ✅ CI job runs all Kani harnesses with timeouts.
- ✅ Non-blocking initially; clear per-package summary.
- ✅ Kani toolchain cached.

## Notes
- Workflow-only change — **no Rust/source changes**, so the existing test/build CI is unaffected.
- This is intentionally non-blocking for now (per the scope); once the harness suite is reliably green, flipping it to blocking is a one-line change (drop the `continue-on-error` / final `exit 0`).
- Targets the harness crates explicitly rather than `--workspace`, since the full Soroban contracts link against host types that Kani can't model (see `docs/kani-integration.md`).

## Testing
- Workflow YAML validated.
- The runner's reporting/loop logic was dry-run locally to confirm it produces the per-package summary and exits 0 (non-blocking) even when a harness fails or times out.
