### PR TITLE
feat(cli): add 'sanctifier watch' for continuous re-analysis on file change (closes #361)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,6 +15,7 @@ This document contains the help content for the `sanctifier` command-line progra
 * [`sanctifier init`↴](#sanctifier-init)
 * [`sanctifier callgraph`↴](#sanctifier-callgraph)
 * [`sanctifier update`↴](#sanctifier-update)
+* [`sanctifier watch`↴](#sanctifier-watch)
 * [`sanctifier verify`↴](#sanctifier-verify)
 * [`sanctifier prove`↴](#sanctifier-prove)
 
@@ -34,6 +35,7 @@ Stellar Soroban Security & Formal Verification Suite
 * `init` — Initialize Sanctifier in a new project
 * `callgraph` — Generate a Graphviz DOT call graph of cross-contract calls (env.invoke_contract)
 * `update` — Check for and download the latest Sanctifier binary
+* `watch` — Watch source files and re-run analysis automatically on change (debounced)
 * `verify` — Verify #[sanctify::invariant] declarations across a contract or workspace
 * `prove` — Run SMT-based formal verification on Soroban token contract invariants
 
@@ -177,6 +179,26 @@ Generate a Graphviz DOT call graph of cross-contract calls (env.invoke_contract)
 Check for and download the latest Sanctifier binary
 
 **Usage:** `sanctifier update`
+
+
+
+## `sanctifier watch`
+
+Watch source files and re-run analysis automatically on change (debounced)
+
+**Usage:** `sanctifier watch [OPTIONS]`
+
+###### **Options:**
+
+* `-p`, `--path <PATH>` — Path to a contract directory, workspace, or single `.rs` file to watch
+
+  Default value: `.`
+* `-d`, `--debounce <DEBOUNCE>` — Debounce window in milliseconds before re-running after a change
+
+  Default value: `300`
+* `-f`, `--format <FORMAT>` — Output format passed through to `analyze` (text | json)
+
+  Default value: `text`
 
 
 

--- a/tooling/sanctifier-cli/Cargo.lock
+++ b/tooling/sanctifier-cli/Cargo.lock
@@ -139,7 +139,7 @@ version = "0.66.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -155,6 +155,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -166,6 +172,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
 ]
 
 [[package]]
@@ -391,6 +406,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,6 +440,17 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -514,6 +555,18 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -647,6 +700,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -674,6 +737,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1081,6 +1153,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1151,6 +1243,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,9 +1276,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -1237,6 +1349,18 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
@@ -1244,6 +1368,18 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -1261,6 +1397,25 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "num-bigint"
@@ -1308,6 +1463,21 @@ checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
@@ -1563,7 +1733,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1686,7 +1856,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1740,6 +1910,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "sanctifier-cli"
 version = "0.1.0"
 dependencies = [
@@ -1749,9 +1928,11 @@ dependencies = [
  "clap",
  "clap-markdown",
  "colored",
+ "ctrlc",
  "curve25519-dalek",
  "hex",
  "merlin",
+ "notify",
  "predicates",
  "rand",
  "regex",
@@ -2340,7 +2521,7 @@ checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.1.1",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -2432,7 +2613,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
@@ -2536,6 +2717,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -2677,6 +2868,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2737,6 +2937,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -2769,6 +2978,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2806,6 +3030,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2818,6 +3048,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2827,6 +3063,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2854,6 +3096,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2863,6 +3111,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2878,6 +3132,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2887,6 +3147,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/tooling/sanctifier-cli/Cargo.toml
+++ b/tooling/sanctifier-cli/Cargo.toml
@@ -19,6 +19,8 @@ colored = "2.0"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 regex = "1.10"
+notify = "6"
+ctrlc = "3.4"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 tempfile = "3.8"
 z3 = "0.12.1"

--- a/tooling/sanctifier-cli/src/commands/mod.rs
+++ b/tooling/sanctifier-cli/src/commands/mod.rs
@@ -6,4 +6,5 @@ pub mod init;
 pub mod prove;
 pub mod update;
 pub mod verify;
+pub mod watch;
 pub mod webhook;

--- a/tooling/sanctifier-cli/src/commands/watch.rs
+++ b/tooling/sanctifier-cli/src/commands/watch.rs
@@ -1,0 +1,192 @@
+use clap::Args;
+use colored::*;
+use notify::{recommended_watcher, EventKind, RecursiveMode, Watcher};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{channel, Receiver, RecvTimeoutError};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+/// Arguments for `sanctifier watch`.
+#[derive(Args)]
+pub struct WatchArgs {
+    /// Path to a contract directory, workspace, or single `.rs` file to watch
+    #[arg(short, long, default_value = ".")]
+    pub path: PathBuf,
+
+    /// Debounce window in milliseconds before re-running after a change
+    #[arg(short, long, default_value = "300")]
+    pub debounce: u64,
+
+    /// Output format passed through to `analyze` (text | json)
+    #[arg(short, long, default_value = "text")]
+    pub format: String,
+}
+
+type WatchEvent = notify::Result<notify::Event>;
+
+/// Returns true when an event represents a created/modified/removed `.rs` file.
+/// Access (read) events and non-Rust paths are ignored so the watcher only
+/// reacts to actual source edits.
+fn is_rs_event(event: &notify::Event) -> bool {
+    let is_mutation = matches!(
+        event.kind,
+        EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+    );
+    is_mutation
+        && event
+            .paths
+            .iter()
+            .any(|p| p.extension().and_then(|e| e.to_str()) == Some("rs"))
+}
+
+/// Run `sanctifier watch`: re-run analysis whenever a `.rs` file under `path`
+/// changes, debounced, until interrupted with Ctrl-C.
+pub fn exec(args: WatchArgs) -> anyhow::Result<()> {
+    if !args.path.exists() {
+        anyhow::bail!("path {:?} does not exist", args.path);
+    }
+
+    let (tx, rx) = channel::<WatchEvent>();
+    let mut watcher = recommended_watcher(move |res| {
+        let _ = tx.send(res);
+    })?;
+    watcher.watch(&args.path, RecursiveMode::Recursive)?;
+
+    // Ctrl-C flips this flag; the loop polls it so shutdown is cooperative and
+    // the watcher/Drop runs cleanly instead of the process being hard-killed.
+    let shutdown = Arc::new(AtomicBool::new(false));
+    {
+        let shutdown = Arc::clone(&shutdown);
+        ctrlc::set_handler(move || shutdown.store(true, Ordering::SeqCst))
+            .map_err(|e| anyhow::anyhow!("failed to install Ctrl-C handler: {e}"))?;
+    }
+
+    // Show results immediately, before the first change.
+    run_analysis(&args);
+    print_watching(&args.path);
+
+    while !shutdown.load(Ordering::SeqCst) {
+        // Poll so Ctrl-C is observed even while idle.
+        match rx.recv_timeout(Duration::from_millis(200)) {
+            Ok(Ok(event)) if is_rs_event(&event) => {
+                debounce(&rx, args.debounce, &shutdown);
+                if shutdown.load(Ordering::SeqCst) {
+                    break;
+                }
+                run_analysis(&args);
+                print_watching(&args.path);
+            }
+            Ok(_) => {} // unrelated event or a watch error — ignore
+            Err(RecvTimeoutError::Timeout) => {}
+            Err(RecvTimeoutError::Disconnected) => break,
+        }
+    }
+
+    println!("\n{} Watch stopped.", "✓".green());
+    Ok(())
+}
+
+/// Wait until source files have been quiet for `debounce_ms`. Each new `.rs`
+/// change resets the timer, so a burst of saves coalesces into a single run and
+/// a change arriving mid-window cancels the pending run.
+fn debounce(rx: &Receiver<WatchEvent>, debounce_ms: u64, shutdown: &AtomicBool) {
+    let window = Duration::from_millis(debounce_ms);
+    let mut deadline = Instant::now() + window;
+
+    loop {
+        if shutdown.load(Ordering::SeqCst) {
+            return;
+        }
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return;
+        }
+        match rx.recv_timeout(remaining) {
+            Ok(Ok(event)) if is_rs_event(&event) => {
+                deadline = Instant::now() + window;
+            }
+            Ok(_) => {}
+            Err(RecvTimeoutError::Timeout) | Err(RecvTimeoutError::Disconnected) => return,
+        }
+    }
+}
+
+/// Clear the screen and re-run `sanctifier analyze` as a child process.
+///
+/// Running analysis in a subprocess keeps the watcher alive: `analyze` calls
+/// `std::process::exit` on findings / invalid projects, which would otherwise
+/// terminate the whole watch session.
+fn run_analysis(args: &WatchArgs) {
+    clear_screen();
+
+    let exe = match std::env::current_exe() {
+        Ok(exe) => exe,
+        Err(e) => {
+            eprintln!("{} could not locate sanctifier binary: {e}", "❌".red());
+            return;
+        }
+    };
+
+    let status = Command::new(exe)
+        .arg("analyze")
+        .arg("--path")
+        .arg(&args.path)
+        .arg("--format")
+        .arg(&args.format)
+        .status();
+
+    if let Err(e) = status {
+        eprintln!("{} failed to run analysis: {e}", "❌".red());
+    }
+}
+
+fn clear_screen() {
+    // ANSI: clear screen + move cursor to home.
+    print!("\x1B[2J\x1B[1;1H");
+    let _ = std::io::stdout().flush();
+}
+
+fn print_watching(path: &Path) {
+    println!(
+        "\n👀 Watching {} for .rs changes — press Ctrl-C to stop.",
+        path.display().to_string().cyan()
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use notify::event::{AccessKind, Event, EventKind, ModifyKind};
+
+    #[test]
+    fn detects_rs_modifications() {
+        let event =
+            Event::new(EventKind::Modify(ModifyKind::Any)).add_path(PathBuf::from("lib.rs"));
+        assert!(is_rs_event(&event));
+    }
+
+    #[test]
+    fn detects_rs_creation_and_removal() {
+        let created = Event::new(EventKind::Create(notify::event::CreateKind::File))
+            .add_path("new.rs".into());
+        let removed = Event::new(EventKind::Remove(notify::event::RemoveKind::File))
+            .add_path("old.rs".into());
+        assert!(is_rs_event(&created));
+        assert!(is_rs_event(&removed));
+    }
+
+    #[test]
+    fn ignores_non_rs_files() {
+        let event = Event::new(EventKind::Modify(ModifyKind::Any)).add_path("notes.txt".into());
+        assert!(!is_rs_event(&event));
+    }
+
+    #[test]
+    fn ignores_access_events() {
+        let event = Event::new(EventKind::Access(AccessKind::Read)).add_path("lib.rs".into());
+        assert!(!is_rs_event(&event));
+    }
+}

--- a/tooling/sanctifier-cli/src/main.rs
+++ b/tooling/sanctifier-cli/src/main.rs
@@ -48,6 +48,8 @@ pub enum Commands {
     },
     /// Check for and download the latest Sanctifier binary
     Update,
+    /// Watch source files and re-run analysis automatically on change (debounced)
+    Watch(commands::watch::WatchArgs),
     /// Verify #[sanctify::invariant] declarations across a contract or workspace
     Verify(commands::verify::VerifyArgs),
     /// Run SMT-based formal verification on Soroban token contract invariants
@@ -141,6 +143,9 @@ fn main() -> anyhow::Result<()> {
         }
         Commands::Update => {
             commands::update::exec()?;
+        }
+        Commands::Watch(args) => {
+            commands::watch::exec(args)?;
         }
         Commands::Verify(args) => {
             commands::verify::exec(args)?;


### PR DESCRIPTION
## Summary

Developers currently run `sanctifier analyze` manually after every save. This PR adds `sanctifier watch`, a continuous analysis mode that re-runs automatically whenever `.rs` source files change, tightening the fix-save-see-results loop.

### Changes

- **`tooling/sanctifier-cli/src/commands/watch.rs`** (new) — Core implementation:
  - Recursive watcher via `notify` (v6, `recommended_watcher`) over `--path`
  - Reacts only to `Create`/`Modify`/`Remove` events on `.rs` files; access events and non-Rust paths are ignored
  - Configurable debounce window (`--debounce`, default 300 ms): timer resets on each change so a burst of saves coalesces into a single run and a change arriving mid-window cancels the pending run
  - Runs `analyze` as a **child process** (`std::process::Command`) rather than calling it directly — prevents `analyze`'s `process::exit` on findings from killing the watcher loop
  - Clears the screen between runs for a clean output
  - Cooperative Ctrl-C shutdown: `ctrlc` crate flips an `AtomicBool`; the event loop polls it every 200 ms so the watcher/Drop runs cleanly
  - 4 unit tests: detects `.rs` modifications, detects creation/removal, ignores non-`.rs` files, ignores access events

- **`tooling/sanctifier-cli/src/commands/mod.rs`** — `pub mod watch;` added

- **`tooling/sanctifier-cli/src/main.rs`** — `Watch(WatchArgs)` variant + dispatch arm added to the `Commands` enum

- **`tooling/sanctifier-cli/Cargo.toml`** — `notify = "6"` and `ctrlc = "3.4"` added

- **`docs/cli.md`** — Regenerated via `generate-docs` subcommand (+22 lines documenting the new `watch` subcommand)

### Usage

```sh
# Watch the current directory (default)
sanctifier watch

# Watch a specific contracts directory with a 500 ms debounce
sanctifier watch --path contracts/ --debounce 500

# Stream JSON output (useful for editor integrations)
sanctifier watch --path . --format json
```

### Test plan

- [x] `cargo test -p sanctifier-cli` — all unit tests pass (4 new `watch` tests)
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo fmt --all --check` — clean
- [x] `docs/cli.md` regenerated and committed
- [x] Manual smoke test: `sanctifier watch --path .` detects a `.rs` save within the debounce window and re-runs analysis

Closes #361