### PR TITLE
Add SANCT_ARG_DOS detector for unbounded argument iteration

### DIFF
--- a/tooling/sanctifier-core/src/finding_codes.rs
+++ b/tooling/sanctifier-core/src/finding_codes.rs
@@ -17,6 +17,7 @@ pub const DEPRECATED_SDK: &str = "S014";
 pub const DEAD_CODE: &str = "S015";
 pub const ERROR_CODE_COLLISION: &str = "S016";
 pub const FEE_ROUNDING: &str = "S017";
+pub const ARG_DOS: &str = "SANCT_ARG_DOS";
 
 #[derive(Debug, Clone, Serialize)]
 pub struct FindingCode {
@@ -113,6 +114,12 @@ pub fn all_finding_codes() -> Vec<FindingCode> {
             category: "arithmetic",
             description:
                 "Fee/interest calculation using integer division rounds to zero for micro-amounts, enabling fee-evasion attacks",
+        },
+        FindingCode {
+            code: ARG_DOS,
+            category: "denial_of_service",
+            description:
+                "Contract entrypoint iterates over a Vec or Map argument without a visible length cap",
         },
     ]
 }

--- a/tooling/sanctifier-core/src/rules/arg_dos.rs
+++ b/tooling/sanctifier-core/src/rules/arg_dos.rs
@@ -1,0 +1,297 @@
+use crate::rules::{Rule, RuleViolation, Severity};
+use std::collections::HashSet;
+use syn::visit::Visit;
+use syn::{parse_str, File};
+
+const FINDING_CODE: &str = "SANCT_ARG_DOS";
+
+/// Detects contract entrypoints that iterate over Vec/Map arguments without a
+/// visible length cap.
+pub struct ArgDosRule;
+
+impl ArgDosRule {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn check_function(
+        &self,
+        fn_name: &str,
+        visibility: &syn::Visibility,
+        sig: &syn::Signature,
+        block: &syn::Block,
+    ) -> Vec<RuleViolation> {
+        if !matches!(visibility, syn::Visibility::Public(_)) {
+            return Vec::new();
+        }
+
+        let arg_collections = collection_args(sig);
+        if arg_collections.is_empty() {
+            return Vec::new();
+        }
+
+        let mut visitor = ArgDosVisitor {
+            arg_collections,
+            capped_args: HashSet::new(),
+            iterations: Vec::new(),
+        };
+        visitor.visit_block(block);
+
+        visitor
+            .iterations
+            .into_iter()
+            .filter(|iteration| !visitor.capped_args.contains(&iteration.arg_name))
+            .map(|iteration| {
+                RuleViolation::new(
+                    FINDING_CODE,
+                    Severity::Warning,
+                    format!(
+                        "{FINDING_CODE}: argument `{}` is iterated without a visible length cap",
+                        iteration.arg_name
+                    ),
+                    format!("{}:{}", fn_name, iteration.line),
+                )
+                .with_suggestion(format!(
+                    "Check `{0}.len()` against a maximum before iterating over `{0}`",
+                    iteration.arg_name
+                ))
+            })
+            .collect()
+    }
+}
+
+impl Default for ArgDosRule {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for ArgDosRule {
+    fn name(&self) -> &str {
+        "arg_dos"
+    }
+
+    fn description(&self) -> &str {
+        "Detects Vec/Map arguments iterated without a visible length cap"
+    }
+
+    fn check(&self, source: &str) -> Vec<RuleViolation> {
+        let file = match parse_str::<File>(source) {
+            Ok(file) => file,
+            Err(_) => return vec![],
+        };
+
+        let mut visitor = ArgDosRuleVisitor {
+            rule: self,
+            violations: Vec::new(),
+        };
+        visitor.visit_file(&file);
+        visitor.violations
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+struct ArgDosRuleVisitor<'rule> {
+    rule: &'rule ArgDosRule,
+    violations: Vec<RuleViolation>,
+}
+
+impl<'ast> Visit<'ast> for ArgDosRuleVisitor<'_> {
+    fn visit_impl_item_fn(&mut self, node: &'ast syn::ImplItemFn) {
+        self.violations.extend(self.rule.check_function(
+            &node.sig.ident.to_string(),
+            &node.vis,
+            &node.sig,
+            &node.block,
+        ));
+        syn::visit::visit_impl_item_fn(self, node);
+    }
+
+    fn visit_item_fn(&mut self, node: &'ast syn::ItemFn) {
+        self.violations.extend(self.rule.check_function(
+            &node.sig.ident.to_string(),
+            &node.vis,
+            &node.sig,
+            &node.block,
+        ));
+        syn::visit::visit_item_fn(self, node);
+    }
+}
+
+struct ArgDosVisitor {
+    arg_collections: HashSet<String>,
+    capped_args: HashSet<String>,
+    iterations: Vec<ArgIteration>,
+}
+
+#[derive(Debug, Clone)]
+struct ArgIteration {
+    arg_name: String,
+    line: usize,
+}
+
+impl<'ast> Visit<'ast> for ArgDosVisitor {
+    fn visit_expr_if(&mut self, node: &'ast syn::ExprIf) {
+        self.record_len_caps(&node.cond);
+        syn::visit::visit_expr_if(self, node);
+    }
+
+    fn visit_expr_while(&mut self, node: &'ast syn::ExprWhile) {
+        self.record_len_caps(&node.cond);
+        syn::visit::visit_expr_while(self, node);
+    }
+
+    fn visit_macro(&mut self, node: &'ast syn::Macro) {
+        if is_assert_or_guard_macro(node) {
+            let tokens = node.tokens.to_string();
+            for arg_name in &self.arg_collections {
+                if tokens_mentions_len(&tokens, arg_name) {
+                    self.capped_args.insert(arg_name.clone());
+                }
+            }
+        }
+        syn::visit::visit_macro(self, node);
+    }
+
+    fn visit_expr_for_loop(&mut self, node: &'ast syn::ExprForLoop) {
+        if let Some(arg_name) = iterated_collection_arg(&node.expr, &self.arg_collections) {
+            self.iterations.push(ArgIteration {
+                arg_name,
+                line: node.for_token.span.start().line,
+            });
+        }
+        syn::visit::visit_expr_for_loop(self, node);
+    }
+}
+
+impl ArgDosVisitor {
+    fn record_len_caps(&mut self, expr: &syn::Expr) {
+        let mut visitor = LenCapVisitor {
+            arg_collections: &self.arg_collections,
+            capped_args: HashSet::new(),
+        };
+        visitor.visit_expr(expr);
+        self.capped_args.extend(visitor.capped_args);
+    }
+}
+
+struct LenCapVisitor<'args> {
+    arg_collections: &'args HashSet<String>,
+    capped_args: HashSet<String>,
+}
+
+impl<'ast> Visit<'ast> for LenCapVisitor<'_> {
+    fn visit_expr_method_call(&mut self, node: &'ast syn::ExprMethodCall) {
+        if node.method == "len" {
+            if let Some(arg_name) = path_ident(&node.receiver) {
+                if self.arg_collections.contains(&arg_name) {
+                    self.capped_args.insert(arg_name);
+                }
+            }
+        }
+        syn::visit::visit_expr_method_call(self, node);
+    }
+}
+
+fn collection_args(sig: &syn::Signature) -> HashSet<String> {
+    sig.inputs
+        .iter()
+        .filter_map(|arg| match arg {
+            syn::FnArg::Typed(pat_type) if is_vec_or_map_type(&pat_type.ty) => {
+                pat_ident(&pat_type.pat)
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+fn pat_ident(pat: &syn::Pat) -> Option<String> {
+    match pat {
+        syn::Pat::Ident(ident) => Some(ident.ident.to_string()),
+        _ => None,
+    }
+}
+
+fn is_vec_or_map_type(ty: &syn::Type) -> bool {
+    match ty {
+        syn::Type::Path(type_path) => type_path
+            .path
+            .segments
+            .last()
+            .is_some_and(|segment| matches!(segment.ident.to_string().as_str(), "Vec" | "Map")),
+        syn::Type::Reference(reference) => is_vec_or_map_type(&reference.elem),
+        _ => false,
+    }
+}
+
+fn iterated_collection_arg(expr: &syn::Expr, arg_collections: &HashSet<String>) -> Option<String> {
+    match expr {
+        syn::Expr::MethodCall(method_call) if method_call.method == "iter" => {
+            path_ident(&method_call.receiver).filter(|name| arg_collections.contains(name))
+        }
+        syn::Expr::Path(_) => path_ident(expr).filter(|name| arg_collections.contains(name)),
+        _ => None,
+    }
+}
+
+fn path_ident(expr: &syn::Expr) -> Option<String> {
+    match expr {
+        syn::Expr::Path(path) if path.path.segments.len() == 1 => path
+            .path
+            .segments
+            .last()
+            .map(|segment| segment.ident.to_string()),
+        syn::Expr::Reference(reference) => path_ident(&reference.expr),
+        _ => None,
+    }
+}
+
+fn is_assert_or_guard_macro(node: &syn::Macro) -> bool {
+    node.path.segments.last().is_some_and(|segment| {
+        matches!(
+            segment.ident.to_string().as_str(),
+            "assert"
+                | "assert_eq"
+                | "assert_ne"
+                | "debug_assert"
+                | "debug_assert_eq"
+                | "debug_assert_ne"
+                | "ensure"
+                | "require"
+        )
+    })
+}
+
+fn tokens_mentions_len(tokens: &str, arg_name: &str) -> bool {
+    let compact: String = tokens.chars().filter(|ch| !ch.is_whitespace()).collect();
+    compact.contains(&format!("{arg_name}.len()"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_uncapped_argument_vector_iteration() {
+        let source = r#"
+            use soroban_sdk::{Address, Env, Vec};
+
+            impl Contract {
+                pub fn airdrop(env: Env, recipients: Vec<Address>) {
+                    for recipient in recipients.iter() {
+                        touch(&env, recipient);
+                    }
+                }
+            }
+        "#;
+
+        let findings = ArgDosRule::new().check(source);
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_name, FINDING_CODE);
+        assert!(findings[0].location.contains("airdrop"));
+    }
+}

--- a/tooling/sanctifier-core/src/rules/mod.rs
+++ b/tooling/sanctifier-core/src/rules/mod.rs
@@ -1,3 +1,4 @@
+pub mod arg_dos;
 pub mod arithmetic_overflow;
 pub mod auth_gap;
 pub mod edge_amount;
@@ -127,6 +128,7 @@ impl RuleRegistry {
         registry.register(edge_amount::EdgeAmountRule::new());
         registry.register(fee_rounding::FeeRoundingRule::new());
         registry.register(missing_ttl::MissingTtlRule::new());
+        registry.register(arg_dos::ArgDosRule::new());
         registry
     }
 }

--- a/tooling/sanctifier-core/tests/detector_snapshots.rs
+++ b/tooling/sanctifier-core/tests/detector_snapshots.rs
@@ -13,11 +13,11 @@
 //! See `tooling/sanctifier-core/tests/README.md` for the full guide.
 
 use sanctifier_core::rules::{
-    arithmetic_overflow::ArithmeticOverflowRule, auth_gap::AuthGapRule,
+    arg_dos::ArgDosRule, arithmetic_overflow::ArithmeticOverflowRule, auth_gap::AuthGapRule,
     edge_amount::EdgeAmountRule, error_code_collision::ErrorCodeCollisionRule,
     fee_rounding::FeeRoundingRule, hardcoded_addr::HardcodedAddrRule, ledger_size::LedgerSizeRule,
     missing_ttl::MissingTtlRule, panic_detection::PanicDetectionRule,
-    unhandled_result::UnhandledResultRule, unused_variable::UnusedVariableRule, Rule,
+    unhandled_result::UnhandledResultRule, unused_variable::UnusedVariableRule, Rule, RuleRegistry,
 };
 
 /// Run a detector against its fixture and snapshot the resulting findings.
@@ -126,4 +126,24 @@ fn snapshot_missing_ttl() {
         &MissingTtlRule::new(),
         include_str!("fixtures/detectors/missing_ttl.rs"),
     );
+}
+
+#[test]
+fn snapshot_arg_dos() {
+    assert_detector_snapshot(
+        "arg_dos",
+        &ArgDosRule::new(),
+        include_str!("fixtures/detectors/arg_dos.rs"),
+    );
+}
+
+#[test]
+fn arg_dos_detector_flags_only_uncapped_argument_iteration() {
+    let findings = RuleRegistry::with_default_rules()
+        .run_by_name(include_str!("fixtures/detectors/arg_dos.rs"), "arg_dos");
+
+    assert_eq!(findings.len(), 1, "{findings:#?}");
+    assert_eq!(findings[0].rule_name, "SANCT_ARG_DOS");
+    assert!(findings[0].message.contains("recipients"));
+    assert!(findings[0].location.contains("uncapped_vec_airdrop"));
 }

--- a/tooling/sanctifier-core/tests/fixtures/corpus/differential-corpus.json
+++ b/tooling/sanctifier-core/tests/fixtures/corpus/differential-corpus.json
@@ -20,7 +20,9 @@
     "error_code_collision": "S016",
     "fee_rounding": "S017",
     "missing_ttl": "S006",
-    "SANCT_TTL_MISSING": "S006"
+    "SANCT_TTL_MISSING": "S006",
+    "arg_dos": "SANCT_ARG_DOS",
+    "SANCT_ARG_DOS": "SANCT_ARG_DOS"
   },
   "overlap_legend": {
     "shared-covered": "Class has an EVM analogue and Sanctifier already flags it.",
@@ -68,11 +70,11 @@
       "title": "Unbounded loop / DoS by gas exhaustion",
       "soroban": { "vulnerable": "unbounded_loop_vulnerable.rs", "fixed": "unbounded_loop_fixed.rs" },
       "solidity": { "vulnerable": "unbounded_loop_vulnerable.sol", "fixed": "unbounded_loop_fixed.sol" },
-      "sanctifier": { "ideal_code": "S006", "observed_codes": [], "status": "planned" },
+      "sanctifier": { "ideal_code": "SANCT_ARG_DOS", "observed_codes": ["SANCT_ARG_DOS"], "status": "flagged" },
       "slither": { "detectors": ["calls-loop", "costly-loop"], "expected": true },
       "aderyn": { "detectors": ["costly-operations-inside-loops"], "expected": true },
-      "overlap": "shared-sanctifier-gap",
-      "notes": "Sanctifier estimates instruction counts but has no detector for caller-controlled unbounded iteration; planned under S006."
+      "overlap": "shared-covered",
+      "notes": "Sanctifier flags caller-controlled Vec/Map argument iteration without a visible length cap via SANCT_ARG_DOS. Slither and Aderyn cover analogous EVM loop-cost patterns."
     },
     {
       "bug_class": "missing_ttl",

--- a/tooling/sanctifier-core/tests/fixtures/detectors/arg_dos.rs
+++ b/tooling/sanctifier-core/tests/fixtures/detectors/arg_dos.rs
@@ -1,0 +1,49 @@
+use soroban_sdk::{Address, Env, Map, Vec};
+
+struct Contract;
+
+impl Contract {
+    pub fn uncapped_vec_airdrop(env: Env, recipients: Vec<Address>, amount: i128) {
+        for recipient in recipients.iter() {
+            mint(&env, &recipient, amount);
+        }
+    }
+
+    pub fn capped_vec_airdrop(env: Env, recipients: Vec<Address>, amount: i128) {
+        if recipients.len() > 100 {
+            panic!("too many recipients");
+        }
+
+        for recipient in recipients.iter() {
+            mint(&env, &recipient, amount);
+        }
+    }
+
+    pub fn capped_map_batch(env: Env, weights: Map<Address, i128>) {
+        assert!(weights.len() <= 50, "too many weights");
+
+        for entry in weights.iter() {
+            apply_weight(&env, entry);
+        }
+    }
+
+    pub fn internal_vec_is_bounded(env: Env, owner: Address) {
+        let mut keys = Vec::new(&env);
+        keys.push_back(owner);
+
+        for key in keys.iter() {
+            touch(&env, key);
+        }
+    }
+
+    fn private_helper_is_not_an_entrypoint(recipients: Vec<Address>) {
+        for recipient in recipients.iter() {
+            inspect(recipient);
+        }
+    }
+}
+
+fn mint(_env: &Env, _recipient: &Address, _amount: i128) {}
+fn apply_weight(_env: &Env, _entry: (Address, i128)) {}
+fn touch(_env: &Env, _key: Address) {}
+fn inspect(_recipient: Address) {}

--- a/tooling/sanctifier-core/tests/snapshots/detector_snapshots__arg_dos.snap
+++ b/tooling/sanctifier-core/tests/snapshots/detector_snapshots__arg_dos.snap
@@ -1,0 +1,9 @@
+---
+source: tooling/sanctifier-core/tests/detector_snapshots.rs
+expression: findings
+---
+- rule_name: SANCT_ARG_DOS
+  severity: Warning
+  message: "SANCT_ARG_DOS: argument `recipients` is iterated without a visible length cap"
+  location: "uncapped_vec_airdrop:7"
+  suggestion: "Check `recipients.len()` against a maximum before iterating over `recipients`"

--- a/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__unbounded_loop_vulnerable.snap
+++ b/tooling/sanctifier-core/tests/snapshots/gallery_snapshots__unbounded_loop_vulnerable.snap
@@ -2,4 +2,8 @@
 source: tooling/sanctifier-core/tests/gallery_snapshots.rs
 expression: findings
 ---
-[]
+- rule_name: SANCT_ARG_DOS
+  severity: Warning
+  message: "SANCT_ARG_DOS: argument `items` is iterated without a visible length cap"
+  location: "sum_all:16"
+  suggestion: "Check `items.len()` against a maximum before iterating over `items`"


### PR DESCRIPTION
## Summary
- add the `SANCT_ARG_DOS` detector for public entrypoints that iterate over `Vec`/`Map` arguments without a visible length cap
- recognize `if`/`while` conditions and assert/guard macros that check `<arg>.len()` before iteration
- register the detector in the default rule registry and finding-code catalog
- add capped/uncapped detector fixture coverage plus gallery and differential corpus snapshot updates

Closes #327.

## Validation
- `cargo fmt --all --check`
- `cargo test -p sanctifier-core --no-default-features --lib`
- `cargo test -p sanctifier-core --no-default-features --test detector_snapshots -- --nocapture`
- `cargo test -p sanctifier-core --no-default-features --test hygiene_rules_test`
- `cargo test -p sanctifier-core --no-default-features --test gallery_snapshots`
- `cargo test -p sanctifier-core --no-default-features --test differential_test -- --nocapture`
- `cargo test -p sanctifier-core --no-default-features --test invariant_integration_test`
- `cargo clippy -p sanctifier-core --no-default-features --lib --test detector_snapshots --test hygiene_rules_test --test gallery_snapshots --test differential_test --test invariant_integration_test --test integration_token_test -- -D warnings`
- `git diff --check`

Note: local all-features runs require a system `z3.h`; this machine does not have the Z3 header available. The GitHub workflow installs `libz3-dev` before all-features clippy/tests.
