### PR TITLE
Add SANCT_UNWRAP detector for contract entrypoints

### DIFF
--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -11,6 +11,29 @@ Sanctifier now uses a unified finding code system across `sanctifier-core` and `
 | `S005` | storage_keys | Potential storage key collision |
 | `S006` | unsafe_patterns | Potentially unsafe language/runtime pattern |
 | `S007` | custom_rule | User-defined custom rule match |
+| `SANCT_UNWRAP` | panic_handling | `unwrap` / `expect` / risky `unwrap_or_default` inside `#[contractimpl]` entrypoints; replace with typed errors or explicit domain defaults |
+
+## Detector catalog
+
+### `SANCT_UNWRAP`
+
+Flags `unwrap()`, `expect(..)`, and risky `unwrap_or_default()` calls inside
+Soroban `#[contractimpl]` entrypoints. In an entrypoint, an attacker-triggered
+missing value can abort the whole transaction or silently turn absent financial
+state into a default value.
+
+```rust
+#[contractimpl]
+impl Token {
+    pub fn balance(env: Env, id: Address) -> i128 {
+        env.storage().persistent().get(&DataKey::Balance(id)).unwrap_or_default()
+    }
+}
+```
+
+Prefer explicit handling: return a typed `Result`, map missing state to a
+domain-specific `Error`, or use an explicit default such as `unwrap_or(0)` only
+when zero is the intended contract state.
 
 ## Where codes appear
 

--- a/tooling/sanctifier-core/src/finding_codes.rs
+++ b/tooling/sanctifier-core/src/finding_codes.rs
@@ -18,6 +18,7 @@ pub const DEAD_CODE: &str = "S015";
 pub const ERROR_CODE_COLLISION: &str = "S016";
 pub const FEE_ROUNDING: &str = "S017";
 pub const ARG_DOS: &str = "SANCT_ARG_DOS";
+pub const SANCT_UNWRAP: &str = "SANCT_UNWRAP";
 
 #[derive(Debug, Clone, Serialize)]
 pub struct FindingCode {
@@ -121,6 +122,12 @@ pub fn all_finding_codes() -> Vec<FindingCode> {
             description:
                 "Contract entrypoint iterates over a Vec or Map argument without a visible length cap",
         },
+        FindingCode {
+            code: SANCT_UNWRAP,
+            category: "panic_handling",
+            description:
+                "Contract entrypoint uses unwrap, expect, or a risky unwrap_or_default fallback",
+        },
     ]
 }
 
@@ -146,5 +153,6 @@ mod tests {
         assert!(codes.iter().any(|c| c.code == STORAGE_COLLISION));
         assert!(codes.iter().any(|c| c.code == UNSAFE_PATTERN));
         assert!(codes.iter().any(|c| c.code == CUSTOM_RULE_MATCH));
+        assert!(codes.iter().any(|c| c.code == SANCT_UNWRAP));
     }
 }

--- a/tooling/sanctifier-core/src/rules/mod.rs
+++ b/tooling/sanctifier-core/src/rules/mod.rs
@@ -8,6 +8,7 @@ pub mod hardcoded_addr;
 pub mod ledger_size;
 pub mod missing_ttl;
 pub mod panic_detection;
+pub mod sanct_unwrap;
 pub mod unhandled_result;
 pub mod unused_variable;
 
@@ -129,6 +130,7 @@ impl RuleRegistry {
         registry.register(fee_rounding::FeeRoundingRule::new());
         registry.register(missing_ttl::MissingTtlRule::new());
         registry.register(arg_dos::ArgDosRule::new());
+        registry.register(sanct_unwrap::SanctUnwrapRule::new());
         registry
     }
 }

--- a/tooling/sanctifier-core/src/rules/sanct_unwrap.rs
+++ b/tooling/sanctifier-core/src/rules/sanct_unwrap.rs
@@ -1,0 +1,314 @@
+use crate::finding_codes::SANCT_UNWRAP;
+use crate::rules::{Rule, RuleViolation, Severity};
+use syn::visit::Visit;
+use syn::{parse_str, Attribute, File};
+
+/// Flags panic-prone option/result handling in Soroban contract entrypoints.
+pub struct SanctUnwrapRule;
+
+impl SanctUnwrapRule {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for SanctUnwrapRule {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for SanctUnwrapRule {
+    fn name(&self) -> &str {
+        "sanct_unwrap"
+    }
+
+    fn description(&self) -> &str {
+        "Detects unwrap/expect/default fallbacks in #[contractimpl] entrypoints"
+    }
+
+    fn check(&self, source: &str) -> Vec<RuleViolation> {
+        let file = match parse_str::<File>(source) {
+            Ok(file) => file,
+            Err(_) => return Vec::new(),
+        };
+
+        let mut visitor = ContractUnwrapVisitor {
+            violations: Vec::new(),
+            suppressions: suppressions(source),
+            test_depth: 0,
+        };
+        visitor.visit_file(&file);
+        visitor.violations
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+struct ContractUnwrapVisitor {
+    violations: Vec<RuleViolation>,
+    suppressions: Vec<usize>,
+    test_depth: usize,
+}
+
+impl ContractUnwrapVisitor {
+    fn in_test_module(&self) -> bool {
+        self.test_depth > 0
+    }
+}
+
+impl<'ast> Visit<'ast> for ContractUnwrapVisitor {
+    fn visit_item_mod(&mut self, node: &'ast syn::ItemMod) {
+        let was_test = has_cfg_test(&node.attrs);
+        if was_test {
+            self.test_depth += 1;
+        }
+
+        syn::visit::visit_item_mod(self, node);
+
+        if was_test {
+            self.test_depth -= 1;
+        }
+    }
+
+    fn visit_item_impl(&mut self, node: &'ast syn::ItemImpl) {
+        if self.in_test_module() || !has_attr(&node.attrs, "contractimpl") {
+            syn::visit::visit_item_impl(self, node);
+            return;
+        }
+
+        for item in &node.items {
+            if let syn::ImplItem::Fn(function) = item {
+                if !matches!(function.vis, syn::Visibility::Public(_)) {
+                    continue;
+                }
+
+                let mut function_visitor = ContractFunctionVisitor {
+                    fn_name: function.sig.ident.to_string(),
+                    fn_returns_financial: returns_financial_type(&function.sig),
+                    issues: Vec::new(),
+                };
+                function_visitor.visit_block(&function.block);
+
+                self.violations.extend(
+                    function_visitor
+                        .issues
+                        .into_iter()
+                        .filter(|issue| !is_suppressed(&self.suppressions, issue.line))
+                        .map(UnwrapIssue::into_violation),
+                );
+            }
+        }
+    }
+}
+
+struct ContractFunctionVisitor {
+    fn_name: String,
+    fn_returns_financial: bool,
+    issues: Vec<UnwrapIssue>,
+}
+
+impl<'ast> Visit<'ast> for ContractFunctionVisitor {
+    fn visit_expr_method_call(&mut self, node: &'ast syn::ExprMethodCall) {
+        let method = node.method.to_string();
+        let should_flag = match method.as_str() {
+            "unwrap" | "expect" => true,
+            "unwrap_or_default" => {
+                self.fn_returns_financial
+                    || receiver_looks_like_contract_storage_get(&node.receiver)
+            }
+            _ => false,
+        };
+
+        if should_flag {
+            self.issues.push(UnwrapIssue {
+                fn_name: self.fn_name.clone(),
+                method,
+                receiver: display_expr(&node.receiver),
+                line: node.method.span().start().line,
+            });
+        }
+
+        syn::visit::visit_expr_method_call(self, node);
+    }
+}
+
+struct UnwrapIssue {
+    fn_name: String,
+    method: String,
+    receiver: String,
+    line: usize,
+}
+
+impl UnwrapIssue {
+    fn into_violation(self) -> RuleViolation {
+        RuleViolation::new(
+            SANCT_UNWRAP,
+            Severity::Warning,
+            format!(
+                "{SANCT_UNWRAP}: `{}` in contract entrypoint `{}` can abort transactions or hide missing state",
+                self.method, self.fn_name
+            ),
+            format!("{}:{}", self.fn_name, self.line),
+        )
+        .with_suggestion(format!(
+            "Replace `{}` on `{}` with typed Result handling, an explicit default, or a domain-specific Error",
+            self.method, self.receiver
+        ))
+    }
+}
+
+fn has_attr(attrs: &[Attribute], name: &str) -> bool {
+    attrs.iter().any(|attr| {
+        attr.path()
+            .segments
+            .last()
+            .is_some_and(|segment| segment.ident == name)
+    })
+}
+
+fn has_cfg_test(attrs: &[Attribute]) -> bool {
+    attrs.iter().any(|attr| {
+        if !attr.path().is_ident("cfg") {
+            return false;
+        }
+
+        match &attr.meta {
+            syn::Meta::List(list) => list
+                .tokens
+                .to_string()
+                .split(|ch: char| !ch.is_alphanumeric() && ch != '_')
+                .any(|part| part == "test"),
+            _ => false,
+        }
+    })
+}
+
+fn returns_financial_type(sig: &syn::Signature) -> bool {
+    match &sig.output {
+        syn::ReturnType::Type(_, ty) => type_path_contains_financial_name(ty),
+        syn::ReturnType::Default => false,
+    }
+}
+
+fn type_path_contains_financial_name(ty: &syn::Type) -> bool {
+    match ty {
+        syn::Type::Path(path) => path.path.segments.iter().any(|segment| {
+            matches!(
+                segment.ident.to_string().as_str(),
+                "i128"
+                    | "u128"
+                    | "i64"
+                    | "u64"
+                    | "i32"
+                    | "u32"
+                    | "Amount"
+                    | "Balance"
+                    | "Balances"
+                    | "Shares"
+                    | "Supply"
+            )
+        }),
+        syn::Type::Reference(reference) => type_path_contains_financial_name(&reference.elem),
+        syn::Type::Tuple(tuple) => tuple.elems.iter().any(type_path_contains_financial_name),
+        _ => false,
+    }
+}
+
+fn receiver_looks_like_contract_storage_get(expr: &syn::Expr) -> bool {
+    let receiver = display_expr(expr);
+    let compact: String = receiver.chars().filter(|ch| !ch.is_whitespace()).collect();
+    compact.contains(".storage().persistent().get")
+        || compact.contains(".storage().instance().get")
+        || compact.contains(".storage().temporary().get")
+}
+
+fn display_expr(expr: &syn::Expr) -> String {
+    let rendered = quote::quote!(#expr).to_string();
+    if rendered.len() > 96 {
+        format!("{}...", &rendered[..93])
+    } else {
+        rendered
+    }
+}
+
+fn suppressions(source: &str) -> Vec<usize> {
+    source
+        .lines()
+        .enumerate()
+        .filter_map(|(index, line)| {
+            line.contains("sanctifier:ignore[SANCT_UNWRAP]")
+                .then_some(index + 1)
+        })
+        .collect()
+}
+
+fn is_suppressed(suppressions: &[usize], line: usize) -> bool {
+    suppressions
+        .iter()
+        .any(|suppressed_line| *suppressed_line == line || *suppressed_line + 1 == line)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_unwrap_only_inside_contractimpl_entrypoints() {
+        let source = r#"
+            use soroban_sdk::{contractimpl, Env};
+
+            #[contractimpl]
+            impl Contract {
+                pub fn entry(env: Env) {
+                    env.storage().instance().get(&"admin").unwrap();
+                }
+            }
+
+            impl Contract {
+                pub fn helper(env: Env) {
+                    env.storage().instance().get(&"helper").unwrap();
+                }
+            }
+        "#;
+
+        let findings = SanctUnwrapRule::new().check(source);
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_name, SANCT_UNWRAP);
+        assert!(findings[0].location.contains("entry"));
+    }
+
+    #[test]
+    fn skips_cfg_test_modules_and_inline_suppression() {
+        let source = r#"
+            use soroban_sdk::{contractimpl, Env};
+
+            #[contractimpl]
+            impl Contract {
+                pub fn suppressed(env: Env) {
+                    // sanctifier:ignore[SANCT_UNWRAP]
+                    env.storage().instance().get(&"admin").unwrap();
+                }
+            }
+
+            #[cfg(test)]
+            mod tests {
+                use super::*;
+
+                #[contractimpl]
+                impl Contract {
+                    pub fn test_entry(env: Env) {
+                        env.storage().instance().get(&"test").unwrap();
+                    }
+                }
+            }
+        "#;
+
+        let findings = SanctUnwrapRule::new().check(source);
+
+        assert!(findings.is_empty(), "{findings:#?}");
+    }
+}

--- a/tooling/sanctifier-core/tests/detector_snapshots.rs
+++ b/tooling/sanctifier-core/tests/detector_snapshots.rs
@@ -17,7 +17,8 @@ use sanctifier_core::rules::{
     edge_amount::EdgeAmountRule, error_code_collision::ErrorCodeCollisionRule,
     fee_rounding::FeeRoundingRule, hardcoded_addr::HardcodedAddrRule, ledger_size::LedgerSizeRule,
     missing_ttl::MissingTtlRule, panic_detection::PanicDetectionRule,
-    unhandled_result::UnhandledResultRule, unused_variable::UnusedVariableRule, Rule, RuleRegistry,
+    sanct_unwrap::SanctUnwrapRule, unhandled_result::UnhandledResultRule,
+    unused_variable::UnusedVariableRule, Rule, RuleRegistry,
 };
 
 /// Run a detector against its fixture and snapshot the resulting findings.
@@ -138,6 +139,15 @@ fn snapshot_arg_dos() {
 }
 
 #[test]
+fn snapshot_sanct_unwrap() {
+    assert_detector_snapshot(
+        "sanct_unwrap",
+        &SanctUnwrapRule::new(),
+        include_str!("fixtures/detectors/sanct_unwrap.rs"),
+    );
+}
+
+#[test]
 fn arg_dos_detector_flags_only_uncapped_argument_iteration() {
     let findings = RuleRegistry::with_default_rules()
         .run_by_name(include_str!("fixtures/detectors/arg_dos.rs"), "arg_dos");
@@ -146,4 +156,17 @@ fn arg_dos_detector_flags_only_uncapped_argument_iteration() {
     assert_eq!(findings[0].rule_name, "SANCT_ARG_DOS");
     assert!(findings[0].message.contains("recipients"));
     assert!(findings[0].location.contains("uncapped_vec_airdrop"));
+}
+
+#[test]
+fn sanct_unwrap_detector_is_registered_in_default_rules() {
+    let findings = RuleRegistry::with_default_rules().run_by_name(
+        include_str!("fixtures/detectors/sanct_unwrap.rs"),
+        "sanct_unwrap",
+    );
+
+    assert_eq!(findings.len(), 3, "{findings:#?}");
+    assert!(findings
+        .iter()
+        .all(|finding| finding.rule_name == "SANCT_UNWRAP"));
 }

--- a/tooling/sanctifier-core/tests/fixtures/corpus/differential-corpus.json
+++ b/tooling/sanctifier-core/tests/fixtures/corpus/differential-corpus.json
@@ -22,7 +22,9 @@
     "missing_ttl": "S006",
     "SANCT_TTL_MISSING": "S006",
     "arg_dos": "SANCT_ARG_DOS",
-    "SANCT_ARG_DOS": "SANCT_ARG_DOS"
+    "SANCT_ARG_DOS": "SANCT_ARG_DOS",
+    "sanct_unwrap": "SANCT_UNWRAP",
+    "SANCT_UNWRAP": "SANCT_UNWRAP"
   },
   "overlap_legend": {
     "shared-covered": "Class has an EVM analogue and Sanctifier already flags it.",

--- a/tooling/sanctifier-core/tests/fixtures/detectors/sanct_unwrap.rs
+++ b/tooling/sanctifier-core/tests/fixtures/detectors/sanct_unwrap.rs
@@ -1,0 +1,55 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+// FIXTURE: sanct_unwrap detector
+// Flags panic-prone unwrap/expect/default fallback calls inside #[contractimpl]
+// entrypoints, but ignores test-only code and helper impls.
+
+#[contract]
+pub struct UnsafeUnwrapContract;
+
+#[contractimpl]
+impl UnsafeUnwrapContract {
+    pub fn admin(env: Env) -> Address {
+        env.storage().instance().get(&"admin").unwrap()
+    }
+
+    pub fn config(env: Env) -> Address {
+        env.storage()
+            .persistent()
+            .get(&"config")
+            .expect("config must exist")
+    }
+
+    pub fn balance(env: Env, id: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&("balance", id))
+            .unwrap_or_default()
+    }
+
+    pub fn safe_balance(env: Env, id: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&("balance", id))
+            .unwrap_or(0)
+    }
+}
+
+impl UnsafeUnwrapContract {
+    pub fn helper(env: Env) -> Address {
+        env.storage().instance().get(&"helper").unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[contractimpl]
+    impl UnsafeUnwrapContract {
+        pub fn test_only(env: Env) -> Address {
+            env.storage().instance().get(&"test").unwrap()
+        }
+    }
+}

--- a/tooling/sanctifier-core/tests/smt_latency_benchmark.rs
+++ b/tooling/sanctifier-core/tests/smt_latency_benchmark.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "smt")]
+
 use sanctifier_core::smt::run_smt_latency_benchmark;
 use std::fs;
 use std::path::PathBuf;

--- a/tooling/sanctifier-core/tests/snapshots/detector_snapshots__sanct_unwrap.snap
+++ b/tooling/sanctifier-core/tests/snapshots/detector_snapshots__sanct_unwrap.snap
@@ -1,0 +1,20 @@
+---
+source: tooling/sanctifier-core/tests/detector_snapshots.rs
+assertion_line: 30
+expression: findings
+---
+- rule_name: SANCT_UNWRAP
+  severity: Warning
+  message: "SANCT_UNWRAP: `unwrap` in contract entrypoint `admin` can abort transactions or hide missing state"
+  location: "admin:14"
+  suggestion: "Replace `unwrap` on `env . storage () . instance () . get (& \"admin\")` with typed Result handling, an explicit default, or a domain-specific Error"
+- rule_name: SANCT_UNWRAP
+  severity: Warning
+  message: "SANCT_UNWRAP: `expect` in contract entrypoint `config` can abort transactions or hide missing state"
+  location: "config:21"
+  suggestion: "Replace `expect` on `env . storage () . persistent () . get (& \"config\")` with typed Result handling, an explicit default, or a domain-specific Error"
+- rule_name: SANCT_UNWRAP
+  severity: Warning
+  message: "SANCT_UNWRAP: `unwrap_or_default` in contract entrypoint `balance` can abort transactions or hide missing state"
+  location: "balance:28"
+  suggestion: "Replace `unwrap_or_default` on `env . storage () . persistent () . get (& (\"balance\" , id))` with typed Result handling, an explicit default, or a domain-specific Error"


### PR DESCRIPTION
## Summary
- add a `SANCT_UNWRAP` detector for `unwrap`, `expect`, and risky `unwrap_or_default` calls inside public `#[contractimpl]` entrypoints
- skip `#[cfg(test)]` modules and support the planned `// sanctifier:ignore[SANCT_UNWRAP]` inline suppression shape
- register the finding code, default rule, differential mapping, detector fixture/snapshot, and error-code catalog docs
- gate the SMT latency benchmark test behind the `smt` feature so `--no-default-features` validation works on machines without local Z3 headers

Closes #307

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p sanctifier-core --no-default-features`
- `cargo clippy -p sanctifier-core --no-default-features --all-targets -- -D warnings`

Note: local default-feature `cargo test` requires `z3.h`; this machine does not have Z3 headers installed, so I used the repository's documented `--no-default-features` path for non-SMT validation.
