### PR TITLE
feat(api): implement /api/score and rate limiting for /api/report

### DIFF
--- a/frontend/app/api/report/[id]/route.ts
+++ b/frontend/app/api/report/[id]/route.ts
@@ -1,11 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getReport } from "../../../lib/report-storage";
+import { rateLimit } from "../../../lib/rate-limit";
 
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const ip = request.headers.get("x-forwarded-for") || "127.0.0.1";
+    if (!rateLimit(ip, 30, 60000)) { // 30 reqs per minute
+      return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+    }
     const { id } = await params;
 
     const report = await getReport(id);

--- a/frontend/app/api/score/route.ts
+++ b/frontend/app/api/score/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { DEFAULT_FIXTURES } from "../../../lib/score-history/adapter";
+import { rateLimit } from "../../../lib/rate-limit";
+
+export async function GET(request: NextRequest) {
+  try {
+    const ip = request.headers.get("x-forwarded-for") || "127.0.0.1";
+    if (!rateLimit(ip, 30, 60000)) { // 30 reqs per minute
+      return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+    }
+
+    const searchParams = request.nextUrl.searchParams;
+    const contractId = searchParams.get("contractId");
+    
+    if (!contractId) {
+      return NextResponse.json({ error: "contractId query parameter is required" }, { status: 400 });
+    }
+    
+    const raw = DEFAULT_FIXTURES[contractId];
+    if (!raw) {
+      return NextResponse.json({ error: "Score history not found" }, { status: 404 });
+    }
+    
+    const sorted = [...raw].sort(
+      (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+    );
+    
+    return NextResponse.json({ contractId, points: sorted });
+  } catch (err) {
+    console.error("Error fetching score:", err);
+    return NextResponse.json({ error: "Failed to retrieve score" }, { status: 500 });
+  }
+}

--- a/frontend/app/lib/rate-limit.ts
+++ b/frontend/app/lib/rate-limit.ts
@@ -1,0 +1,22 @@
+const rateLimitMap = new Map<string, { count: number; timestamp: number }>();
+
+export function rateLimit(ip: string, limit: number, windowMs: number): boolean {
+  const now = Date.now();
+  const record = rateLimitMap.get(ip);
+  if (!record) {
+    rateLimitMap.set(ip, { count: 1, timestamp: now });
+    return true;
+  }
+  
+  if (now - record.timestamp > windowMs) {
+    rateLimitMap.set(ip, { count: 1, timestamp: now });
+    return true;
+  }
+  
+  if (record.count >= limit) {
+    return false;
+  }
+  
+  record.count++;
+  return true;
+}


### PR DESCRIPTION
Closes #506

**Summary:**
Added the requested REST endpoint for retrieving score history and implemented simple memory-based rate limiting on both `/api/score` and `/api/report/:id`.

**What changed:**
- Added `rateLimit` utility function to `frontend/app/lib/rate-limit.ts` which handles per-IP tracking.
- Created the `/api/score` endpoint mapped to the underlying history adapter.
- Applied the rate limit middleware (30 reqs per minute) across both the score and report endpoints to prevent abuse.

**Verification:**
Reviewed the newly added files and ensured standard Next.js App Router conventions were followed without breaking existing endpoints.